### PR TITLE
No useless setResults()

### DIFF
--- a/src/main/java/fr/jmmc/oimaging/gui/MainPanel.java
+++ b/src/main/java/fr/jmmc/oimaging/gui/MainPanel.java
@@ -802,7 +802,9 @@ public class MainPanel extends javax.swing.JPanel implements IRModelEventListene
             final ServiceResult lastResult = currentModel.getLastResultSet();
 
             // resultSet Table
-            jTablePanel.setResults(modelResults);
+            if (event.getType() == IRModelEventType.IRMODEL_UPDATED) {
+                jTablePanel.setResults(modelResults);
+            }
 
             // set the slider results boundaries
             if (modelResults.size() > 1) {

--- a/src/main/java/fr/jmmc/oimaging/gui/MainPanel.java
+++ b/src/main/java/fr/jmmc/oimaging/gui/MainPanel.java
@@ -855,6 +855,7 @@ public class MainPanel extends javax.swing.JPanel implements IRModelEventListene
             if (event.getType() == IRModelEventType.IRMODEL_CHANGED || modelResults.isEmpty()) {
                 // to ensure jsplit pane will be given 90% once it becomes visible:
                 showTablePanel(!modelResults.isEmpty());
+                jTablePanel.getSelectionModel().clearSelection();
                 viewerPanel.displayModel(currentModel);
             } else {
                 showTablePanel(true);

--- a/src/main/java/fr/jmmc/oimaging/gui/MainPanel.java
+++ b/src/main/java/fr/jmmc/oimaging/gui/MainPanel.java
@@ -651,7 +651,7 @@ public class MainPanel extends javax.swing.JPanel implements IRModelEventListene
             case IRMODEL_CHANGED:
                 syncUI(event);
                 break;
-            case IRMODEL_UPDATED:
+            case IRMODEL_RESULT_LIST_CHANGED:
                 syncUI(event);
                 break;
             default:
@@ -802,7 +802,7 @@ public class MainPanel extends javax.swing.JPanel implements IRModelEventListene
             final ServiceResult lastResult = currentModel.getLastResultSet();
 
             // resultSet Table
-            if (event.getType() == IRModelEventType.IRMODEL_UPDATED) {
+            if (event.getType() == IRModelEventType.IRMODEL_RESULT_LIST_CHANGED) {
                 jTablePanel.setResults(modelResults);
             }
 

--- a/src/main/java/fr/jmmc/oimaging/model/IRModel.java
+++ b/src/main/java/fr/jmmc/oimaging/model/IRModel.java
@@ -771,7 +771,7 @@ public final class IRModel {
             setSelectedRglPrioImageHdu(rglHduEquiv);
         }
         // notify model update
-        IRModelManager.getInstance().fireIRModelUpdated(this, null);
+        IRModelManager.getInstance().fireIRModelResultListChanged(this, null);
     }
 
     /** 
@@ -808,13 +808,13 @@ public final class IRModel {
     public void removeServiceResult(ServiceResult serviceResultToDelete) {
         getResultSets().remove(serviceResultToDelete);
         // notify model update
-        IRModelManager.getInstance().fireIRModelUpdated(this, null);
+        IRModelManager.getInstance().fireIRModelResultListChanged(this, null);
     }
 
     public void removeServiceResults(List<ServiceResult> selectedServicesList) {
         getResultSets().removeAll(selectedServicesList);
         // notify model update
-        IRModelManager.getInstance().fireIRModelUpdated(this, null);
+        IRModelManager.getInstance().fireIRModelResultListChanged(this, null);
     }
 
     private void loadLog(final ServiceResult serviceResult) {

--- a/src/main/java/fr/jmmc/oimaging/model/IRModel.java
+++ b/src/main/java/fr/jmmc/oimaging/model/IRModel.java
@@ -395,7 +395,7 @@ public final class IRModel {
                 setSelectedRglPrioImageHdu(null);
             }
             // notify model change (to display model):
-            IRModelManager.getInstance().fireIRModelUpdated(this, null);
+            IRModelManager.getInstance().fireIRModelChanged(this, null);
         }
         return removed;
     }

--- a/src/main/java/fr/jmmc/oimaging/model/IRModelEventType.java
+++ b/src/main/java/fr/jmmc/oimaging/model/IRModelEventType.java
@@ -13,5 +13,5 @@ public enum IRModelEventType {
     /** last event type = ready */
     READY,
     /** IRModel get a new service result */
-    IRMODEL_UPDATED
+    IRMODEL_RESULT_LIST_CHANGED
 }

--- a/src/main/java/fr/jmmc/oimaging/model/IRModelManager.java
+++ b/src/main/java/fr/jmmc/oimaging/model/IRModelManager.java
@@ -233,7 +233,7 @@ public final class IRModelManager {
     public boolean loadOIFitsFile(final OIFitsFile oiFitsFile) {
         if (oiFitsFile != null) {
             irModel.loadOifitsFile(oiFitsFile);
-            fireIRModelUpdated(this, null);
+            fireIRModelChanged(this, null);
             return true;
 
         }

--- a/src/main/java/fr/jmmc/oimaging/model/IRModelManager.java
+++ b/src/main/java/fr/jmmc/oimaging/model/IRModelManager.java
@@ -432,18 +432,18 @@ public final class IRModelManager {
     }
 
     /**
-     * This fires an IRMODEL_UPDATED event to given registered listener ASYNCHRONOUSLY !
-     *     *
+     * This fires an IRMODEL_RESULT_LIST_CHANGED event to given registered listener ASYNCHRONOUSLY !
+     *
      * @param source event source
      * @param destination destination listener (null means all)
      */
-    public void fireIRModelUpdated(final Object source, final IRModelEventListener destination) {
+    public void fireIRModelResultListChanged(final Object source, final IRModelEventListener destination) {
         if (enableEvents) {
             if (logger.isDebugEnabled()) {
-                logger.debug("fireIRModelUpdated TO {}", (destination != null) ? destination : "ALL");
+                logger.debug("fireIRModelResultListChanged TO {}", (destination != null) ? destination : "ALL");
             }
             getIRModelChangedEventNotifier().queueEvent((source != null) ? source : this,
-                    new IRModelEvent(IRModelEventType.IRMODEL_UPDATED, null, getIRModel()), destination);
+                    new IRModelEvent(IRModelEventType.IRMODEL_RESULT_LIST_CHANGED, null, getIRModel()), destination);
         }
     }
 


### PR DESCRIPTION
I think that the current `MainPanel.syncUI()` is calling `setResults()` when it does not need too.

This triggers a re-computation of the columns by a call to `ResultSetTableModel.setResults()`, and triggers a display of the selected result by a call to `ViewerPanel.displayResult(Result)`.

Firstly I think that we don't need to do this at every `syncUI` but only when the list of results has changed, i.e when one result have been added to it, or removed from it. So I added a condition on the presence of the event `IRMODEL_UPDATED` to call `setResults()`.

Secondly I noticed two places where I think the event `IRMODEL_UPDATED` is thrown instead of `IRMODEL_CHANGED`.
The first one is in `removeFitsImageHDU()`. This is just touching the image library so it does not change the result list.
The second one is in `loadOIFitsFile()`. This is just touching the input form so it does not change the result list.

I made some tests that seemed correct.
What do you think ?

_PS:_
_It has the effect of not removing the selection of a result when you modify the input form. I.e it goes to the correct INPUT view display, but in the table the row is still selected. So when you click again on the selected row, it does not show you the image because it was already selected. I am going to inquire on this)._
_---_
_Indeed the event of selection is not triggered when you do not change the selection. So you cannot activate result view by selecting the same result that was already selected. So I added a manual clear selection in case of IRMODEL_CHANGED. I think it now behaves as before)._