### PR TITLE
New toolbar with button

### DIFF
--- a/src/main/java/fr/jmmc/oimaging/OImaging.java
+++ b/src/main/java/fr/jmmc/oimaging/OImaging.java
@@ -25,16 +25,19 @@ import fr.jmmc.oiexplorer.core.model.PlotDefinitionFactory;
 import fr.jmmc.oimaging.gui.MainPanel;
 import fr.jmmc.oimaging.gui.PreferencePanel;
 import fr.jmmc.oimaging.gui.ViewerPanel.ProcessImageOperation;
+import fr.jmmc.oimaging.gui.action.LoadResultAsInputAction;
 import fr.jmmc.oimaging.gui.action.CreateImageAction;
 import fr.jmmc.oimaging.gui.action.DeleteSelectionAction;
 import fr.jmmc.oimaging.gui.action.ExportFitsImageAction;
 import fr.jmmc.oimaging.gui.action.ExportOIFitsAction;
 import fr.jmmc.oimaging.gui.action.LoadFitsImageAction;
 import fr.jmmc.oimaging.gui.action.LoadOIFitsAction;
+import fr.jmmc.oimaging.gui.action.RunMoreIterationsAction;
 import fr.jmmc.oimaging.gui.action.NewAction;
 import fr.jmmc.oimaging.gui.action.ProcessImageAction;
 import fr.jmmc.oimaging.gui.action.OIFitsBrowserAction;
 import fr.jmmc.oimaging.gui.action.RunAction;
+import fr.jmmc.oimaging.gui.action.SetAsInitImgAction;
 import fr.jmmc.oimaging.gui.action.SwitchTabAction;
 import fr.jmmc.oimaging.gui.action.TableEditorAction;
 import fr.jmmc.oimaging.interop.SendFitsAction;
@@ -333,6 +336,9 @@ public final class OImaging extends App {
 
         // Processing menu :
         new RunAction();
+        new LoadResultAsInputAction();
+        new RunMoreIterationsAction();
+        new SetAsInitImgAction();
         new CreateImageAction();
         
         for (ProcessImageOperation op : ProcessImageOperation.values()) {

--- a/src/main/java/fr/jmmc/oimaging/gui/MainPanel.form
+++ b/src/main/java/fr/jmmc/oimaging/gui/MainPanel.form
@@ -470,11 +470,61 @@
 
                       <Layout class="org.netbeans.modules.form.compat2.layouts.DesignFlowLayout"/>
                       <SubComponents>
+                        <Component class="javax.swing.JButton" name="jButtonRunMoreIterations">
+                          <Properties>
+                            <Property name="action" type="javax.swing.Action" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
+                              <Connection code="ActionRegistrar.getInstance().get(fr.jmmc.oimaging.gui.action.RunMoreIterationsAction.CLASS_NAME, fr.jmmc.oimaging.gui.action.RunMoreIterationsAction.ACTION_NAME)" type="code"/>
+                            </Property>
+                            <Property name="text" type="java.lang.String" value="Run more iterations"/>
+                          </Properties>
+                          <Constraints>
+                            <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+                              <GridBagConstraints gridX="0" gridY="0" gridWidth="1" gridHeight="1" fill="2" ipadX="0" ipadY="0" insetsTop="2" insetsLeft="2" insetsBottom="2" insetsRight="2" anchor="10" weightX="0.0" weightY="0.0"/>
+                            </Constraint>
+                          </Constraints>
+                        </Component>
+                        <Component class="javax.swing.JButton" name="jButtonLoadAsInput">
+                          <Properties>
+                            <Property name="action" type="javax.swing.Action" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
+                              <Connection code="ActionRegistrar.getInstance().get(fr.jmmc.oimaging.gui.action.LoadResultAsInputAction.CLASS_NAME, fr.jmmc.oimaging.gui.action.LoadResultAsInputAction.ACTION_NAME)" type="code"/>
+                            </Property>
+                            <Property name="text" type="java.lang.String" value="Load as input"/>
+                            <Property name="actionCommand" type="java.lang.String" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
+                              <Connection code="LoadResultAsInputAction.USE_INIT_IMG_AS_INIT" type="code"/>
+                            </Property>
+                          </Properties>
+                          <Constraints>
+                            <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+                              <GridBagConstraints gridX="0" gridY="1" gridWidth="1" gridHeight="1" fill="2" ipadX="0" ipadY="0" insetsTop="2" insetsLeft="2" insetsBottom="2" insetsRight="2" anchor="10" weightX="0.0" weightY="0.0"/>
+                            </Constraint>
+                          </Constraints>
+                        </Component>
+                        <Component class="javax.swing.JButton" name="jButtonLoadAsInputWithLastImg">
+                          <Properties>
+                            <Property name="action" type="javax.swing.Action" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
+                              <Connection code="ActionRegistrar.getInstance().get(fr.jmmc.oimaging.gui.action.LoadResultAsInputAction.CLASS_NAME, fr.jmmc.oimaging.gui.action.LoadResultAsInputAction.ACTION_NAME)" type="code"/>
+                            </Property>
+                            <Property name="text" type="java.lang.String" value="Load as input with last img"/>
+                            <Property name="actionCommand" type="java.lang.String" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
+                              <Connection code="LoadResultAsInputAction.USE_LAST_IMG_AS_INIT" type="code"/>
+                            </Property>
+                          </Properties>
+                          <Constraints>
+                            <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+                              <GridBagConstraints gridX="0" gridY="2" gridWidth="1" gridHeight="1" fill="2" ipadX="0" ipadY="0" insetsTop="2" insetsLeft="2" insetsBottom="2" insetsRight="2" anchor="10" weightX="0.0" weightY="0.0"/>
+                            </Constraint>
+                          </Constraints>
+                        </Component>
                         <Component class="javax.swing.JButton" name="jButtonExportOIFits">
                           <Properties>
-                            <Property name="text" type="java.lang.String" value="[Save]"/>
+                            <Property name="text" type="java.lang.String" value="Save OIFitsFile"/>
                             <Property name="name" type="java.lang.String" value="jButtonExportOIFits" noResource="true"/>
                           </Properties>
+                          <Constraints>
+                            <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+                              <GridBagConstraints gridX="0" gridY="3" gridWidth="1" gridHeight="1" fill="2" ipadX="0" ipadY="0" insetsTop="2" insetsLeft="2" insetsBottom="2" insetsRight="2" anchor="10" weightX="0.0" weightY="0.0"/>
+                            </Constraint>
+                          </Constraints>
                         </Component>
                       </SubComponents>
                     </Container>

--- a/src/main/java/fr/jmmc/oimaging/gui/MainPanel.form
+++ b/src/main/java/fr/jmmc/oimaging/gui/MainPanel.form
@@ -477,11 +477,6 @@
                             </Property>
                             <Property name="text" type="java.lang.String" value="Run more iterations"/>
                           </Properties>
-                          <Constraints>
-                            <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
-                              <GridBagConstraints gridX="0" gridY="0" gridWidth="1" gridHeight="1" fill="2" ipadX="0" ipadY="0" insetsTop="2" insetsLeft="2" insetsBottom="2" insetsRight="2" anchor="10" weightX="0.0" weightY="0.0"/>
-                            </Constraint>
-                          </Constraints>
                         </Component>
                         <Component class="javax.swing.JButton" name="jButtonLoadAsInput">
                           <Properties>
@@ -493,11 +488,6 @@
                               <Connection code="LoadResultAsInputAction.USE_INIT_IMG_AS_INIT" type="code"/>
                             </Property>
                           </Properties>
-                          <Constraints>
-                            <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
-                              <GridBagConstraints gridX="0" gridY="1" gridWidth="1" gridHeight="1" fill="2" ipadX="0" ipadY="0" insetsTop="2" insetsLeft="2" insetsBottom="2" insetsRight="2" anchor="10" weightX="0.0" weightY="0.0"/>
-                            </Constraint>
-                          </Constraints>
                         </Component>
                         <Component class="javax.swing.JButton" name="jButtonLoadAsInputWithLastImg">
                           <Properties>
@@ -509,22 +499,12 @@
                               <Connection code="LoadResultAsInputAction.USE_LAST_IMG_AS_INIT" type="code"/>
                             </Property>
                           </Properties>
-                          <Constraints>
-                            <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
-                              <GridBagConstraints gridX="0" gridY="2" gridWidth="1" gridHeight="1" fill="2" ipadX="0" ipadY="0" insetsTop="2" insetsLeft="2" insetsBottom="2" insetsRight="2" anchor="10" weightX="0.0" weightY="0.0"/>
-                            </Constraint>
-                          </Constraints>
                         </Component>
                         <Component class="javax.swing.JButton" name="jButtonExportOIFits">
                           <Properties>
                             <Property name="text" type="java.lang.String" value="Save OIFitsFile"/>
                             <Property name="name" type="java.lang.String" value="jButtonExportOIFits" noResource="true"/>
                           </Properties>
-                          <Constraints>
-                            <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
-                              <GridBagConstraints gridX="0" gridY="3" gridWidth="1" gridHeight="1" fill="2" ipadX="0" ipadY="0" insetsTop="2" insetsLeft="2" insetsBottom="2" insetsRight="2" anchor="10" weightX="0.0" weightY="0.0"/>
-                            </Constraint>
-                          </Constraints>
                         </Component>
                       </SubComponents>
                     </Container>

--- a/src/main/java/fr/jmmc/oimaging/gui/MainPanel.java
+++ b/src/main/java/fr/jmmc/oimaging/gui/MainPanel.java
@@ -811,9 +811,11 @@ public class MainPanel extends javax.swing.JPanel implements IRModelEventListene
         sendFitsAction.setEnabled(enableExportImage);
 
         final boolean exactlyOneResultSelected = (this.getResultSetTablePanel().getSelectedRows().size() == 1);
+        final boolean selectedIsSuccess
+                = exactlyOneResultSelected && this.getResultSetTablePanel().getSelectedRow().isValid();
 
-        loadResultAsInputAction.setEnabled(exactlyOneResultSelected);
-        runMoreIterationsAction.setEnabled(exactlyOneResultSelected);
+        loadResultAsInputAction.setEnabled(selectedIsSuccess);
+        runMoreIterationsAction.setEnabled(selectedIsSuccess);
 
         boolean someImageDisplayed = false;
         ViewerPanel viewerPanel = this.getViewerPanelActive();
@@ -823,7 +825,7 @@ public class MainPanel extends javax.swing.JPanel implements IRModelEventListene
                 someImageDisplayed = true;
             }
         }
-        setAsInitImgAction.setEnabled(exactlyOneResultSelected && someImageDisplayed);
+        setAsInitImgAction.setEnabled(selectedIsSuccess && someImageDisplayed);
     }
 
     // Variables declaration - do not modify//GEN-BEGIN:variables

--- a/src/main/java/fr/jmmc/oimaging/gui/MainPanel.java
+++ b/src/main/java/fr/jmmc/oimaging/gui/MainPanel.java
@@ -16,11 +16,14 @@ import fr.jmmc.oiexplorer.core.model.OIFitsCollectionManager;
 import fr.jmmc.oiexplorer.core.model.oi.Plot;
 import fr.jmmc.oiexplorer.core.model.oi.SubsetDefinition;
 import fr.jmmc.oiexplorer.core.model.plot.PlotDefinition;
+import fr.jmmc.oimaging.gui.action.LoadResultAsInputAction;
 import fr.jmmc.oimaging.gui.action.DeleteSelectionAction;
 import fr.jmmc.oimaging.gui.action.ExportFitsImageAction;
 import fr.jmmc.oimaging.gui.action.ExportOIFitsAction;
 import fr.jmmc.oimaging.gui.action.LoadOIFitsAction;
 import fr.jmmc.oimaging.gui.action.RunAction;
+import fr.jmmc.oimaging.gui.action.RunMoreIterationsAction;
+import fr.jmmc.oimaging.gui.action.SetAsInitImgAction;
 import fr.jmmc.oimaging.interop.SendFitsAction;
 import fr.jmmc.oimaging.interop.SendOIFitsAction;
 import fr.jmmc.oimaging.model.IRModel;
@@ -29,6 +32,7 @@ import fr.jmmc.oimaging.model.IRModelEventListener;
 import fr.jmmc.oimaging.model.IRModelEventType;
 import fr.jmmc.oimaging.model.IRModelManager;
 import fr.jmmc.oimaging.services.ServiceResult;
+import fr.jmmc.oitools.image.FitsImageHDU;
 import fr.jmmc.oitools.image.FitsUnit;
 import fr.jmmc.oitools.image.ImageOiConstants;
 import fr.jmmc.oitools.image.ImageOiInputParam;
@@ -89,6 +93,9 @@ public class MainPanel extends javax.swing.JPanel implements IRModelEventListene
     private Action sendOiFitsAction;
     private Action exportFitsImageAction;
     private Action sendFitsAction;
+    private Action loadResultAsInputAction;
+    private Action runMoreIterationsAction;
+    private Action setAsInitImgAction;
 
     /** Flag set to true while the GUI is being updated by model else false. */
     private boolean syncingUI = false;
@@ -298,6 +305,12 @@ public class MainPanel extends javax.swing.JPanel implements IRModelEventListene
         sendOiFitsAction = ActionRegistrar.getInstance().get(SendOIFitsAction.className, SendOIFitsAction.actionName);
         exportFitsImageAction = ActionRegistrar.getInstance().get(ExportFitsImageAction.className, ExportFitsImageAction.actionName);
         sendFitsAction = ActionRegistrar.getInstance().get(SendFitsAction.className, SendFitsAction.actionName);
+
+        loadResultAsInputAction = ActionRegistrar.getInstance().get(LoadResultAsInputAction.CLASS_NAME, LoadResultAsInputAction.ACTION_NAME);
+        runMoreIterationsAction = ActionRegistrar.getInstance().get(
+                RunMoreIterationsAction.CLASS_NAME, RunMoreIterationsAction.ACTION_NAME);
+        setAsInitImgAction = ActionRegistrar.getInstance().get(
+                SetAsInitImgAction.CLASS_NAME, SetAsInitImgAction.ACTION_NAME);
     }
 
     @Override
@@ -353,6 +366,9 @@ public class MainPanel extends javax.swing.JPanel implements IRModelEventListene
         jPanelViewerAndActions = new javax.swing.JPanel();
         viewerPanelResults = new fr.jmmc.oimaging.gui.ViewerPanel();
         jPanelResultsActions = new javax.swing.JPanel();
+        jButtonRunMoreIterations = new javax.swing.JButton();
+        jButtonLoadAsInput = new javax.swing.JButton();
+        jButtonLoadAsInputWithLastImg = new javax.swing.JButton();
         jButtonExportOIFits = new javax.swing.JButton();
         jTablePanel = new fr.jmmc.oimaging.gui.ResultSetTablePanel();
 
@@ -629,10 +645,45 @@ public class MainPanel extends javax.swing.JPanel implements IRModelEventListene
         jPanelViewerAndActions.add(viewerPanelResults, gridBagConstraints);
 
         jPanelResultsActions.setBorder(javax.swing.BorderFactory.createTitledBorder("Action panel"));
+        jPanelResultsActions.setLayout(new java.awt.GridBagLayout());
 
-        jButtonExportOIFits.setText("[Save]");
+        jButtonRunMoreIterations.setAction(ActionRegistrar.getInstance().get(fr.jmmc.oimaging.gui.action.RunMoreIterationsAction.CLASS_NAME, fr.jmmc.oimaging.gui.action.RunMoreIterationsAction.ACTION_NAME));
+        jButtonRunMoreIterations.setText("Run more iterations");
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.gridx = 0;
+        gridBagConstraints.gridy = 0;
+        gridBagConstraints.fill = java.awt.GridBagConstraints.HORIZONTAL;
+        gridBagConstraints.insets = new java.awt.Insets(2, 2, 2, 2);
+        jPanelResultsActions.add(jButtonRunMoreIterations, gridBagConstraints);
+
+        jButtonLoadAsInput.setAction(ActionRegistrar.getInstance().get(fr.jmmc.oimaging.gui.action.LoadResultAsInputAction.CLASS_NAME, fr.jmmc.oimaging.gui.action.LoadResultAsInputAction.ACTION_NAME));
+        jButtonLoadAsInput.setText("Load as input");
+        jButtonLoadAsInput.setActionCommand(LoadResultAsInputAction.USE_INIT_IMG_AS_INIT);
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.gridx = 0;
+        gridBagConstraints.gridy = 1;
+        gridBagConstraints.fill = java.awt.GridBagConstraints.HORIZONTAL;
+        gridBagConstraints.insets = new java.awt.Insets(2, 2, 2, 2);
+        jPanelResultsActions.add(jButtonLoadAsInput, gridBagConstraints);
+
+        jButtonLoadAsInputWithLastImg.setAction(ActionRegistrar.getInstance().get(fr.jmmc.oimaging.gui.action.LoadResultAsInputAction.CLASS_NAME, fr.jmmc.oimaging.gui.action.LoadResultAsInputAction.ACTION_NAME));
+        jButtonLoadAsInputWithLastImg.setText("Load as input with last img");
+        jButtonLoadAsInputWithLastImg.setActionCommand(LoadResultAsInputAction.USE_LAST_IMG_AS_INIT);
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.gridx = 0;
+        gridBagConstraints.gridy = 2;
+        gridBagConstraints.fill = java.awt.GridBagConstraints.HORIZONTAL;
+        gridBagConstraints.insets = new java.awt.Insets(2, 2, 2, 2);
+        jPanelResultsActions.add(jButtonLoadAsInputWithLastImg, gridBagConstraints);
+
+        jButtonExportOIFits.setText("Save OIFitsFile");
         jButtonExportOIFits.setName("jButtonExportOIFits"); // NOI18N
-        jPanelResultsActions.add(jButtonExportOIFits);
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.gridx = 0;
+        gridBagConstraints.gridy = 3;
+        gridBagConstraints.fill = java.awt.GridBagConstraints.HORIZONTAL;
+        gridBagConstraints.insets = new java.awt.Insets(2, 2, 2, 2);
+        jPanelResultsActions.add(jButtonExportOIFits, gridBagConstraints);
 
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.gridx = 0;
@@ -735,6 +786,9 @@ public class MainPanel extends javax.swing.JPanel implements IRModelEventListene
         } else {
             logger.warn("valueChanged: Unsupported component : {}", e.getSource());
         }
+
+        // some actions may become (dis/en)abled when the result selection changes (for example empty selection)
+        updateEnabledActions();
     }
 
     /**
@@ -755,13 +809,31 @@ public class MainPanel extends javax.swing.JPanel implements IRModelEventListene
         final boolean enableExportImage = (!activeViewerPanel.isFitsImageNull());
         exportFitsImageAction.setEnabled(enableExportImage);
         sendFitsAction.setEnabled(enableExportImage);
+
+        final boolean exactlyOneResultSelected = (this.getResultSetTablePanel().getSelectedRows().size() == 1);
+
+        loadResultAsInputAction.setEnabled(exactlyOneResultSelected);
+        runMoreIterationsAction.setEnabled(exactlyOneResultSelected);
+
+        boolean someImageDisplayed = false;
+        ViewerPanel viewerPanel = this.getViewerPanelActive();
+        if (viewerPanel != null) {
+            FitsImageHDU fihdu = viewerPanel.getDisplayedFitsImageHDU();
+            if (fihdu != null) {
+                someImageDisplayed = true;
+            }
+        }
+        setAsInitImgAction.setEnabled(exactlyOneResultSelected && someImageDisplayed);
     }
 
     // Variables declaration - do not modify//GEN-BEGIN:variables
     private javax.swing.JButton jButtonCompare;
     private javax.swing.JButton jButtonExportOIFits;
+    private javax.swing.JButton jButtonLoadAsInput;
+    private javax.swing.JButton jButtonLoadAsInputWithLastImg;
     private javax.swing.JButton jButtonLoadData;
     private javax.swing.JButton jButtonRun;
+    private javax.swing.JButton jButtonRunMoreIterations;
     private javax.swing.JCheckBox jCheckBoxUseT3;
     private javax.swing.JCheckBox jCheckBoxUseVis;
     private javax.swing.JCheckBox jCheckBoxUseVis2;

--- a/src/main/java/fr/jmmc/oimaging/gui/MainPanel.java
+++ b/src/main/java/fr/jmmc/oimaging/gui/MainPanel.java
@@ -170,6 +170,7 @@ public class MainPanel extends javax.swing.JPanel implements IRModelEventListene
         registerActions();
 
         IRModelManager.getInstance().bindIRModelChangedEvent(this);
+        IRModelManager.getInstance().getRunEventNotifier().register(this);
 
         // associate sliders and fields
         fieldSliderAdapterWaveMin = new FieldSliderAdapter(jSliderWaveMin, jFormattedTextFieldWaveMin, 0, 1, 0);
@@ -886,6 +887,9 @@ public class MainPanel extends javax.swing.JPanel implements IRModelEventListene
             case IRMODEL_RESULT_LIST_CHANGED:
                 syncUI(event);
                 break;
+            case RUN:
+                jButtonRun.doClick();
+                jTabbedPaneTwoTabsDisplay.setSelectedIndex(TABS.RESULTS.ordinal());
             default:
                 logger.info("event not handled : {}", event);
         }

--- a/src/main/java/fr/jmmc/oimaging/gui/OIFitsViewPanel.java
+++ b/src/main/java/fr/jmmc/oimaging/gui/OIFitsViewPanel.java
@@ -173,14 +173,6 @@ public final class OIFitsViewPanel extends javax.swing.JPanel implements Disposa
     }
 
     /**
-     * Define the OIFits data
-     * @param oiFitsFile OIFits data
-     */
-    private void setOIFitsData(final OIFitsFile oiFitsFile) {
-        this.oiFitsFile = oiFitsFile;
-    }
-
-    /**
      * Plot OIFits data using embedded OIFitsExplorer Plot panel
      * This code must be executed by the Swing Event Dispatcher thread (EDT)
      * @param oiFitsFileParam OIFits data

--- a/src/main/java/fr/jmmc/oimaging/gui/ViewerPanel.form
+++ b/src/main/java/fr/jmmc/oimaging/gui/ViewerPanel.form
@@ -140,6 +140,19 @@
               </Events>
               <Constraints>
                 <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+                  <GridBagConstraints gridX="5" gridY="0" gridWidth="1" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="2" insetsLeft="2" insetsBottom="2" insetsRight="2" anchor="10" weightX="0.0" weightY="0.0"/>
+                </Constraint>
+              </Constraints>
+            </Component>
+            <Component class="javax.swing.JButton" name="jButtonSetAsInitImg">
+              <Properties>
+                <Property name="action" type="javax.swing.Action" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
+                  <Connection code="ActionRegistrar.getInstance().get(SetAsInitImgAction.CLASS_NAME, SetAsInitImgAction.ACTION_NAME)" type="code"/>
+                </Property>
+                <Property name="text" type="java.lang.String" value="Set as Init Img"/>
+              </Properties>
+              <Constraints>
+                <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
                   <GridBagConstraints gridX="4" gridY="0" gridWidth="1" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="2" insetsLeft="2" insetsBottom="2" insetsRight="2" anchor="10" weightX="0.0" weightY="0.0"/>
                 </Constraint>
               </Constraints>
@@ -166,7 +179,7 @@
               </Properties>
               <Constraints>
                 <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
-                  <GridBagConstraints gridX="5" gridY="0" gridWidth="1" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="0" insetsBottom="0" insetsRight="0" anchor="10" weightX="0.0" weightY="0.0"/>
+                  <GridBagConstraints gridX="6" gridY="0" gridWidth="1" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="0" insetsBottom="0" insetsRight="0" anchor="10" weightX="0.0" weightY="0.0"/>
                 </Constraint>
               </Constraints>
             </Component>

--- a/src/main/java/fr/jmmc/oimaging/gui/ViewerPanel.java
+++ b/src/main/java/fr/jmmc/oimaging/gui/ViewerPanel.java
@@ -5,6 +5,7 @@ package fr.jmmc.oimaging.gui;
 
 import fr.jmmc.jmcs.data.MimeType;
 import fr.jmmc.jmcs.gui.FeedbackReport;
+import fr.jmmc.jmcs.gui.action.ActionRegistrar;
 import fr.jmmc.jmcs.gui.component.FileChooser;
 import fr.jmmc.jmcs.gui.util.AutofitTableColumns;
 import fr.jmmc.jmcs.gui.util.SwingUtils;
@@ -15,6 +16,7 @@ import fr.jmmc.oiexplorer.core.gui.SliderPanel;
 import fr.jmmc.oiexplorer.core.gui.model.KeywordsTableModel;
 import fr.jmmc.oimaging.OImaging;
 import fr.jmmc.oimaging.Preferences;
+import fr.jmmc.oimaging.gui.action.SetAsInitImgAction;
 import fr.jmmc.oimaging.model.IRModel;
 import fr.jmmc.oimaging.model.IRModelManager;
 import fr.jmmc.oimaging.services.ServiceResult;
@@ -194,7 +196,7 @@ public class ViewerPanel extends javax.swing.JPanel implements ChangeListener {
             FitsImage image = imageHDU.getFitsImages().get(0);
             fitsImagePanel.setFitsImage(image);
             jPanelImage.add(fitsImagePanel);
-            logger.debug("Display image HDU '{}'", imageHDU.getHduName());
+            logger.debug("Display image HDU {} '{}'", this.showMode, imageHDU.getHduName());
         } else {
             // reset anyway
             fitsImagePanel.setFitsImage(null);
@@ -234,12 +236,15 @@ public class ViewerPanel extends javax.swing.JPanel implements ChangeListener {
             // change border title
             switch (mode) {
                 case MODEL:
+                    this.jButtonSetAsInitImg.setVisible(false);
                     setBorder(javax.swing.BorderFactory.createTitledBorder("Data Visualisation (INPUT)"));
                     break;
                 case RESULT:
+                    this.jButtonSetAsInitImg.setVisible(true);
                     setBorder(javax.swing.BorderFactory.createTitledBorder("Data Visualisation (RESULT)"));
                     break;
                 case GRID:
+                    this.jButtonSetAsInitImg.setVisible(true);
                     setBorder(javax.swing.BorderFactory.createTitledBorder("Data Visualisation (GRID)"));
                     break;
             }
@@ -575,12 +580,13 @@ public class ViewerPanel extends javax.swing.JPanel implements ChangeListener {
 
             // add modified image into image library and select it if appropriate:
             IRModelManager.getInstance().getIRModel().addFitsImageHDUAndSelect(fitsImageHDU, copyFitsImageHDU);
-        } else {
-            if ((fitsImagePanel.getFitsImage() != null)
-                    && (copyFitsImageHDU == fitsImagePanel.getFitsImage().getFitsImageHDU())) {
-                // restore initial image if displayed:
-                displaySelection(fitsImageHDU);
-            }
+        }
+
+        // restore initial image, but only if initial image have not changed:
+        // during the dialog, some async action (like run) could have changed it
+        if ((fitsImagePanel.getFitsImage() != null)
+                && (copyFitsImageHDU == fitsImagePanel.getFitsImage().getFitsImageHDU())) {
+            displaySelection(fitsImageHDU);
         }
     }
 
@@ -636,6 +642,7 @@ public class ViewerPanel extends javax.swing.JPanel implements ChangeListener {
         jButtonViewport = new javax.swing.JButton();
         jButtonResample = new javax.swing.JButton();
         jButtonModifyImage = new javax.swing.JButton();
+        jButtonSetAsInitImg = new javax.swing.JButton();
         jButtonRescale = new javax.swing.JButton();
         jLabelImageDebug = new javax.swing.JLabel();
         jPanelImage = new javax.swing.JPanel();
@@ -723,10 +730,18 @@ public class ViewerPanel extends javax.swing.JPanel implements ChangeListener {
             }
         });
         gridBagConstraints = new java.awt.GridBagConstraints();
-        gridBagConstraints.gridx = 4;
+        gridBagConstraints.gridx = 5;
         gridBagConstraints.gridy = 0;
         gridBagConstraints.insets = new java.awt.Insets(2, 2, 2, 2);
         jPanelImageViewer.add(jButtonModifyImage, gridBagConstraints);
+
+        jButtonSetAsInitImg.setAction(ActionRegistrar.getInstance().get(SetAsInitImgAction.CLASS_NAME, SetAsInitImgAction.ACTION_NAME));
+        jButtonSetAsInitImg.setText("Set as Init Img");
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.gridx = 4;
+        gridBagConstraints.gridy = 0;
+        gridBagConstraints.insets = new java.awt.Insets(2, 2, 2, 2);
+        jPanelImageViewer.add(jButtonSetAsInitImg, gridBagConstraints);
 
         jButtonRescale.setText("Rescale");
         jButtonRescale.addActionListener(new java.awt.event.ActionListener() {
@@ -743,7 +758,7 @@ public class ViewerPanel extends javax.swing.JPanel implements ChangeListener {
         jLabelImageDebug.setForeground(java.awt.Color.red);
         jLabelImageDebug.setText("Debug");
         gridBagConstraints = new java.awt.GridBagConstraints();
-        gridBagConstraints.gridx = 5;
+        gridBagConstraints.gridx = 6;
         gridBagConstraints.gridy = 0;
         jPanelImageViewer.add(jLabelImageDebug, gridBagConstraints);
 
@@ -856,6 +871,7 @@ public class ViewerPanel extends javax.swing.JPanel implements ChangeListener {
     private javax.swing.JButton jButtonModifyImage;
     private javax.swing.JButton jButtonResample;
     private javax.swing.JButton jButtonRescale;
+    private javax.swing.JButton jButtonSetAsInitImg;
     private javax.swing.JButton jButtonViewport;
     private javax.swing.JComboBox jComboBoxImage;
     private javax.swing.JEditorPane jEditorPaneExecutionLog;
@@ -952,5 +968,17 @@ public class ViewerPanel extends javax.swing.JPanel implements ChangeListener {
      */
     public boolean isFitsImageNull() {
         return this.fitsImagePanel.getFitsImage() == null;
+    }
+
+    public FitsImageHDU getDisplayedFitsImageHDU() {
+
+        final FitsImage fitsImage = fitsImagePanel.getFitsImage();
+
+        if (fitsImage == null) {
+            return null;
+        }
+        else {
+            return fitsImage.getFitsImageHDU();
+        }
     }
 }

--- a/src/main/java/fr/jmmc/oimaging/gui/ViewerPanel.java
+++ b/src/main/java/fr/jmmc/oimaging/gui/ViewerPanel.java
@@ -600,6 +600,18 @@ public class ViewerPanel extends javax.swing.JPanel implements ChangeListener {
         final FitsImageHDU newHDU = fitsImagePanel.createFitsImage();
 
         if (newHDU != null) {
+
+            // update keywords
+            try {
+                final BasicHDU basicHdu = FitsImageWriter.createHDUnit(newHDU);
+                // clear the header cards, because basicHdu already have all of them updated
+                // not clearing them would make processKeywords() to output duplicates header cards.
+                newHDU.getHeaderCards().clear();
+                FitsImageLoader.processKeywords(null, basicHdu.getHeader(), newHDU);
+            } catch (FitsException e) {
+                logger.info(e.getMessage());
+            }
+
             // update checksum:
             newHDU.updateChecksum();
 

--- a/src/main/java/fr/jmmc/oimaging/gui/ViewerPanel.java
+++ b/src/main/java/fr/jmmc/oimaging/gui/ViewerPanel.java
@@ -172,6 +172,8 @@ public class ViewerPanel extends javax.swing.JPanel implements ChangeListener {
                 }
             } else {
                 logger.debug("Remove image panel");
+                // reset anyway
+                fitsImagePanel.setFitsImage(null);
                 jPanelImage.remove(fitsImagePanel);
             }
         } finally {
@@ -564,9 +566,6 @@ public class ViewerPanel extends javax.swing.JPanel implements ChangeListener {
 
         // show dialog and waits for user action (async changes may happen):
         if (operation.action(fitsImagePanel)) {
-            // update checksum:
-            copyFitsImageHDU.updateChecksum();
-
             // update keywords
             try {
                 final BasicHDU basicHdu = FitsImageWriter.createHDUnit(copyFitsImageHDU);
@@ -612,9 +611,6 @@ public class ViewerPanel extends javax.swing.JPanel implements ChangeListener {
                 logger.info(e.getMessage());
             }
 
-            // update checksum:
-            newHDU.updateChecksum();
-
             // add the FitsImageHDU to the imageLibrary
             final List<FitsImageHDU> libraryHDUs = irModel.addFitsImageHDUs(Arrays.asList(newHDU), "(created)");
 
@@ -631,7 +627,7 @@ public class ViewerPanel extends javax.swing.JPanel implements ChangeListener {
             displayModel(irModel);
 
             // notify model update
-            irModelManager.fireIRModelChanged(this, null);
+            irModelManager.fireIRModelChanged(this);
         }
     }
 
@@ -992,8 +988,7 @@ public class ViewerPanel extends javax.swing.JPanel implements ChangeListener {
 
         if (fitsImage == null) {
             return null;
-        }
-        else {
+        } else {
             return fitsImage.getFitsImageHDU();
         }
     }

--- a/src/main/java/fr/jmmc/oimaging/gui/ViewerPanel.java
+++ b/src/main/java/fr/jmmc/oimaging/gui/ViewerPanel.java
@@ -982,6 +982,10 @@ public class ViewerPanel extends javax.swing.JPanel implements ChangeListener {
         return this.fitsImagePanel.getFitsImage() == null;
     }
 
+    /**
+     * return the FitsImageHDU parent to the FitsImage (potentially) displayed.
+     * @return the FitsImageHDU if a FitsImage is displayed, null otherwise.
+     */
     public FitsImageHDU getDisplayedFitsImageHDU() {
 
         final FitsImage fitsImage = fitsImagePanel.getFitsImage();

--- a/src/main/java/fr/jmmc/oimaging/gui/action/CreateImageAction.java
+++ b/src/main/java/fr/jmmc/oimaging/gui/action/CreateImageAction.java
@@ -14,6 +14,9 @@ import org.slf4j.LoggerFactory;
  */
 public class CreateImageAction extends RegisteredAction {
 
+    /** default serial UID for Serializable interface */
+    private static final long serialVersionUID = 1;
+
     /** Class logger */
     private static final Logger logger = LoggerFactory.getLogger(CreateImageAction.class);
 

--- a/src/main/java/fr/jmmc/oimaging/gui/action/DeleteSelectionAction.java
+++ b/src/main/java/fr/jmmc/oimaging/gui/action/DeleteSelectionAction.java
@@ -11,6 +11,9 @@ import org.slf4j.LoggerFactory;
 
 public class DeleteSelectionAction extends RegisteredAction {
 
+    /** default serial UID for Serializable interface */
+    private static final long serialVersionUID = 1;
+
     /** Class name. This name is used to register to the ActionRegistrar */
     public final static String className = DeleteSelectionAction.class.getName();
     /** Action name. This name is used to register to the ActionRegistrar */
@@ -18,7 +21,6 @@ public class DeleteSelectionAction extends RegisteredAction {
 
     /** Class logger */
     private static final Logger logger = LoggerFactory.getLogger(className);
-    private static final long serialVersionUID = 1L;
 
     public DeleteSelectionAction() {
         super(className, actionName);

--- a/src/main/java/fr/jmmc/oimaging/gui/action/LoadResultAsInputAction.java
+++ b/src/main/java/fr/jmmc/oimaging/gui/action/LoadResultAsInputAction.java
@@ -4,8 +4,12 @@
 package fr.jmmc.oimaging.gui.action;
 
 import fr.jmmc.jmcs.gui.action.RegisteredAction;
+import fr.jmmc.oimaging.OImaging;
+import fr.jmmc.oimaging.gui.MainPanel;
 import fr.jmmc.oimaging.model.IRModelManager;
+import fr.jmmc.oimaging.services.ServiceResult;
 import java.awt.event.ActionEvent;
+import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -66,7 +70,15 @@ public class LoadResultAsInputAction extends RegisteredAction {
                 useLastImgAsInit = true;
                 break;
         }
+        MainPanel mainPanel = OImaging.getInstance().getMainPanel();
+        List<ServiceResult> selectedResultList = mainPanel.getResultSetTablePanel().getSelectedRows();
 
-        IRModelManager.getInstance().loadResultAsInput(useLastImgAsInit);
+        if (selectedResultList.size() == 1) {
+            ServiceResult selectedResult = selectedResultList.get(0);
+
+            IRModelManager.getInstance().loadResultAsInput(selectedResult, useLastImgAsInit);
+        } else {
+            LOGGER.error("Cannot procede LoadResultAsInputAction when the number of selected results != 1");
+        }
     }
 }

--- a/src/main/java/fr/jmmc/oimaging/gui/action/LoadResultAsInputAction.java
+++ b/src/main/java/fr/jmmc/oimaging/gui/action/LoadResultAsInputAction.java
@@ -18,6 +18,9 @@ import org.slf4j.LoggerFactory;
  */
 public class LoadResultAsInputAction extends RegisteredAction {
 
+    /** default serial UID for Serializable interface */
+    private static final long serialVersionUID = 1;
+
     /**
      * Class logger
      */

--- a/src/main/java/fr/jmmc/oimaging/gui/action/LoadResultAsInputAction.java
+++ b/src/main/java/fr/jmmc/oimaging/gui/action/LoadResultAsInputAction.java
@@ -1,0 +1,72 @@
+/** *****************************************************************************
+ * JMMC project ( http://www.jmmc.fr ) - Copyright (C) CNRS.
+ ***************************************************************************** */
+package fr.jmmc.oimaging.gui.action;
+
+import fr.jmmc.jmcs.gui.action.RegisteredAction;
+import fr.jmmc.oimaging.model.IRModelManager;
+import java.awt.event.ActionEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Change parameters.
+ */
+public class LoadResultAsInputAction extends RegisteredAction {
+
+    /**
+     * Class logger
+     */
+    private static final Logger LOGGER = LoggerFactory.getLogger(LoadResultAsInputAction.class);
+
+    /**
+     * Class name. This name is used to register to the ActionRegistrar
+     */
+    public final static String CLASS_NAME = LoadResultAsInputAction.class.getName();
+    /**
+     * Action name. This name is used to register to the ActionRegistrar
+     */
+    public final static String ACTION_NAME = "loadResultAsInput";
+
+    /**
+     * Constant indicating we want to use the last img as init img
+     */
+    public final static String USE_LAST_IMG_AS_INIT = "USE_LAST_IMG_AS_INIT";
+
+    /**
+     * Constant indicating we want to use the init img as init img
+     */
+    public final static String USE_INIT_IMG_AS_INIT = "USE_INIT_IMG_AS_INIT";
+
+    /**
+     * Public constructor that automatically register the action in RegisteredAction.
+     */
+    public LoadResultAsInputAction() {
+        super(CLASS_NAME, ACTION_NAME);
+    }
+
+    /**
+     * Handle the action event
+     *
+     * @param evt action event
+     */
+    @Override
+    public void actionPerformed(final ActionEvent evt) {
+        LOGGER.debug("actionPerformed");
+
+        final boolean useLastImgAsInit;
+        switch (evt.getActionCommand()) {
+            case USE_INIT_IMG_AS_INIT:
+                useLastImgAsInit = false;
+                break;
+            case USE_LAST_IMG_AS_INIT:
+                useLastImgAsInit = true;
+                break;
+            default:
+                useLastImgAsInit = true;
+                break;
+        }
+
+        IRModelManager.getInstance().loadResultAsInput(useLastImgAsInit);
+    }
+}

--- a/src/main/java/fr/jmmc/oimaging/gui/action/RunAction.java
+++ b/src/main/java/fr/jmmc/oimaging/gui/action/RunAction.java
@@ -3,6 +3,7 @@
  ******************************************************************************/
 package fr.jmmc.oimaging.gui.action;
 
+import fr.jmmc.jmcs.gui.action.ActionRegistrar;
 import fr.jmmc.jmcs.gui.action.RegisteredAction;
 import fr.jmmc.jmcs.gui.component.MessagePane;
 import fr.jmmc.jmcs.gui.component.StatusBar;
@@ -22,6 +23,7 @@ import java.net.UnknownHostException;
 import java.util.Date;
 import java.util.concurrent.ExecutionException;
 import javax.swing.Action;
+import javax.swing.ImageIcon;
 import org.apache.commons.httpclient.ConnectTimeoutException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,6 +39,10 @@ public class RunAction extends RegisteredAction {
     public static final String actionName = "run";
     /** Task Run IR */
     public static final Task TASK_RUN_IR = new Task("RUN_IR");
+    /**
+     * Spinner icon gif to decorate "cancel" label.
+     */
+    private static final ImageIcon spinnerIcon = ImageUtils.loadResourceIcon("fr/jmmc/jmcs/resource/image/spinner.gif");
 
     public RunAction() {
         super(className, actionName);
@@ -45,7 +51,16 @@ public class RunAction extends RegisteredAction {
     private void setRunningState(final IRModel irModel, boolean running) {
         irModel.setRunning(running);
         putValue(Action.NAME, (running) ? "Cancel" : "Run");
-        putValue(Action.LARGE_ICON_KEY, running ? ImageUtils.loadResourceIcon("fr/jmmc/jmcs/resource/image/spinner.gif") : null);
+        putValue(Action.LARGE_ICON_KEY, running ? spinnerIcon : null);
+
+        // update associated RunMoreIterationsAction label and icon
+        Action runMoreIterationsAction = ActionRegistrar.getInstance().get(
+                RunMoreIterationsAction.CLASS_NAME, RunMoreIterationsAction.ACTION_NAME);
+        if (runMoreIterationsAction != null) {
+            runMoreIterationsAction.putValue(RunMoreIterationsAction.NAME,
+                    running ? RunMoreIterationsAction.LABEL_CANCEL : RunMoreIterationsAction.LABEL_IDLE);
+            runMoreIterationsAction.putValue(Action.LARGE_ICON_KEY, running ? spinnerIcon : null);
+        }
     }
 
     @Override

--- a/src/main/java/fr/jmmc/oimaging/gui/action/RunAction.java
+++ b/src/main/java/fr/jmmc/oimaging/gui/action/RunAction.java
@@ -109,14 +109,12 @@ public class RunAction extends RegisteredAction {
             final Service service = irModel.getSelectedService();
             ServiceResult result = null;
             try {
-                boolean valid = false;
-
                 result = service.getExecMode().reconstructsImage(service.getProgram(), cliOptions, inputFile);
                 result.setService(service);
 
                 if (result.getErrorMessage() == null) {
                     // Result is valid only if the OIFITS file was downloaded successfully:
-                    valid = result.getOifitsResultFile().exists();
+                    boolean valid = result.getOifitsResultFile().exists();
                     result.setValid(valid);
 
                     if (!valid) {

--- a/src/main/java/fr/jmmc/oimaging/gui/action/RunMoreIterationsAction.java
+++ b/src/main/java/fr/jmmc/oimaging/gui/action/RunMoreIterationsAction.java
@@ -18,6 +18,8 @@ import org.slf4j.LoggerFactory;
  */
 public class RunMoreIterationsAction extends RegisteredAction {
 
+    private static final long serialVersionUID = 1L;
+
     /**
      * Class logger
      */
@@ -63,10 +65,11 @@ public class RunMoreIterationsAction extends RegisteredAction {
 
             // need to check success, in case loadResultAsInput failed
             if (success) {
-                // launch a Run
-                irModelManager.fireRun(this, null);
+                // disable allowChangeTwoTabs flag:
+                mainPanel.setAllowChangeTwoTabs(false);
+                // launch a Run (async) that will restore the allowChangeTwoTabs flag later:
+                irModelManager.fireRun(this);
             }
-
         } else {
             LOGGER.error("Cannot procede RunMoreIterationsAction when the number of selected results != 1");
         }

--- a/src/main/java/fr/jmmc/oimaging/gui/action/RunMoreIterationsAction.java
+++ b/src/main/java/fr/jmmc/oimaging/gui/action/RunMoreIterationsAction.java
@@ -4,8 +4,12 @@
 package fr.jmmc.oimaging.gui.action;
 
 import fr.jmmc.jmcs.gui.action.RegisteredAction;
+import fr.jmmc.oimaging.OImaging;
+import fr.jmmc.oimaging.gui.MainPanel;
 import fr.jmmc.oimaging.model.IRModelManager;
+import fr.jmmc.oimaging.services.ServiceResult;
 import java.awt.event.ActionEvent;
+import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,7 +50,26 @@ public class RunMoreIterationsAction extends RegisteredAction {
     @Override
     public void actionPerformed(final ActionEvent evt) {
         LOGGER.debug("actionPerformed");
-        IRModelManager.getInstance().runMoreIterations();
+
+        MainPanel mainPanel = OImaging.getInstance().getMainPanel();
+        List<ServiceResult> selectedResultList = mainPanel.getResultSetTablePanel().getSelectedRows();
+
+        if (selectedResultList.size() == 1) {
+            ServiceResult selectedResult = selectedResultList.get(0);
+
+            IRModelManager irModelManager = IRModelManager.getInstance();
+            boolean useLastImgAsInit = true;
+            boolean success = irModelManager.loadResultAsInput(selectedResult, useLastImgAsInit);
+
+            // need to check success, in case loadResultAsInput failed
+            if (success) {
+                // launch a Run
+                irModelManager.fireRun(this, null);
+            }
+
+        } else {
+            LOGGER.error("Cannot procede RunMoreIterationsAction when the number of selected results != 1");
+        }
     }
 
 }

--- a/src/main/java/fr/jmmc/oimaging/gui/action/RunMoreIterationsAction.java
+++ b/src/main/java/fr/jmmc/oimaging/gui/action/RunMoreIterationsAction.java
@@ -1,0 +1,52 @@
+/** *****************************************************************************
+ * JMMC project ( http://www.jmmc.fr ) - Copyright (C) CNRS.
+ ***************************************************************************** */
+package fr.jmmc.oimaging.gui.action;
+
+import fr.jmmc.jmcs.gui.action.RegisteredAction;
+import fr.jmmc.oimaging.model.IRModelManager;
+import java.awt.event.ActionEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Load selected Result as input and trigger RunAction.
+ */
+public class RunMoreIterationsAction extends RegisteredAction {
+
+    /**
+     * Class logger
+     */
+    private static final Logger LOGGER = LoggerFactory.getLogger(RunMoreIterationsAction.class);
+
+    /**
+     * Class name. This name is used to register to the ActionRegistrar
+     */
+    public final static String CLASS_NAME = RunMoreIterationsAction.class.getName();
+    /**
+     * Action name. This name is used to register to the ActionRegistrar
+     */
+    public final static String ACTION_NAME = "runMoreIterations";
+
+    public final static String LABEL_IDLE = "Run more iterations";
+    public final static String LABEL_CANCEL = "Cancel";
+
+    /**
+     * Public constructor that automatically register the action in RegisteredAction.
+     */
+    public RunMoreIterationsAction() {
+        super(CLASS_NAME, ACTION_NAME);
+    }
+
+    /**
+     * Handle the action event
+     *
+     * @param evt action event
+     */
+    @Override
+    public void actionPerformed(final ActionEvent evt) {
+        LOGGER.debug("actionPerformed");
+        IRModelManager.getInstance().runMoreIterations();
+    }
+
+}

--- a/src/main/java/fr/jmmc/oimaging/gui/action/SetAsInitImgAction.java
+++ b/src/main/java/fr/jmmc/oimaging/gui/action/SetAsInitImgAction.java
@@ -1,0 +1,48 @@
+/** *****************************************************************************
+ * JMMC project ( http://www.jmmc.fr ) - Copyright (C) CNRS.
+ ***************************************************************************** */
+package fr.jmmc.oimaging.gui.action;
+
+import fr.jmmc.jmcs.gui.action.RegisteredAction;
+import fr.jmmc.oimaging.model.IRModelManager;
+import java.awt.event.ActionEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Set as init image.
+ */
+public class SetAsInitImgAction extends RegisteredAction {
+
+    /**
+     * Class logger
+     */
+    private static final Logger LOGGER = LoggerFactory.getLogger(SetAsInitImgAction.class);
+
+    /**
+     * Class name. This name is used to register to the ActionRegistrar
+     */
+    public final static String CLASS_NAME = SetAsInitImgAction.class.getName();
+    /**
+     * Action name. This name is used to register to the ActionRegistrar
+     */
+    public final static String ACTION_NAME = "setAsInitImg";
+
+    /**
+     * Public constructor that automatically register the action in RegisteredAction.
+     */
+    public SetAsInitImgAction() {
+        super(CLASS_NAME, ACTION_NAME);
+    }
+
+    /**
+     * Handle the action event
+     *
+     * @param evt action event
+     */
+    @Override
+    public void actionPerformed(final ActionEvent evt) {
+        LOGGER.debug("actionPerformed");
+        IRModelManager.getInstance().setAsInitImg();
+    }
+}

--- a/src/main/java/fr/jmmc/oimaging/gui/action/SetAsInitImgAction.java
+++ b/src/main/java/fr/jmmc/oimaging/gui/action/SetAsInitImgAction.java
@@ -17,6 +17,9 @@ import org.slf4j.LoggerFactory;
  */
 public class SetAsInitImgAction extends RegisteredAction {
 
+    /** default serial UID for Serializable interface */
+    private static final long serialVersionUID = 1;
+
     /**
      * Class logger
      */

--- a/src/main/java/fr/jmmc/oimaging/gui/action/SetAsInitImgAction.java
+++ b/src/main/java/fr/jmmc/oimaging/gui/action/SetAsInitImgAction.java
@@ -4,7 +4,10 @@
 package fr.jmmc.oimaging.gui.action;
 
 import fr.jmmc.jmcs.gui.action.RegisteredAction;
+import fr.jmmc.oimaging.OImaging;
+import fr.jmmc.oimaging.gui.ViewerPanel;
 import fr.jmmc.oimaging.model.IRModelManager;
+import fr.jmmc.oitools.image.FitsImageHDU;
 import java.awt.event.ActionEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -43,6 +46,17 @@ public class SetAsInitImgAction extends RegisteredAction {
     @Override
     public void actionPerformed(final ActionEvent evt) {
         LOGGER.debug("actionPerformed");
-        IRModelManager.getInstance().setAsInitImg();
+
+        ViewerPanel viewerPanel = OImaging.getInstance().getMainPanel().getViewerPanelActive();
+        if (viewerPanel != null) {
+            FitsImageHDU fihdu = viewerPanel.getDisplayedFitsImageHDU();
+            if (fihdu != null) {
+                IRModelManager.getInstance().setAsInitImg(fihdu);
+            } else {
+                LOGGER.error("Cannot procede SetAsInitImgAction because selected image is null");
+            }
+        } else {
+            LOGGER.error("Cannot procede SetAsInitImgAction because active viewer panel is null");
+        }
     }
 }

--- a/src/main/java/fr/jmmc/oimaging/gui/action/SwitchTabAction.java
+++ b/src/main/java/fr/jmmc/oimaging/gui/action/SwitchTabAction.java
@@ -14,6 +14,9 @@ import org.slf4j.LoggerFactory;
  */
 public class SwitchTabAction extends RegisteredAction {
 
+    /** default serial UID for Serializable interface */
+    private static final long serialVersionUID = 1;
+
     /** Class logger */
     private static final Logger LOGGER = LoggerFactory.getLogger(SwitchTabAction.class);
 

--- a/src/main/java/fr/jmmc/oimaging/model/IRModel.java
+++ b/src/main/java/fr/jmmc/oimaging/model/IRModel.java
@@ -787,10 +787,13 @@ public final class IRModel {
      * return false if one of them has checksum = 0. The decision to compute expensively the checksum is on the caller.
      */
     private static boolean hduEquals(final FitsImageHDU first, final FitsImageHDU second) {
-        boolean equiv = FitsImageHDU.MATCHER.match(first, second);
-        logger.info("hdus {} and {} equiv: {}",
-                first == null ? "null" : first.getHduName(), second == null ? "null" : second.getHduName(), equiv);
-        return equiv;
+        boolean match = FitsImageHDU.MATCHER.match(first, second);
+        if (logger.isDebugEnabled()) {
+            logger.debug("hdus {} and {} match: {}",
+                    (first == null) ? "null" : first.getHduName(),
+                    (second == null) ? "null" : second.getHduName(), match);
+        }
+        return match;
     }
 
     // --- ServiceResult handling ---

--- a/src/main/java/fr/jmmc/oimaging/model/IRModel.java
+++ b/src/main/java/fr/jmmc/oimaging/model/IRModel.java
@@ -489,6 +489,7 @@ public final class IRModel {
                 FitsImageHDU libraryHDU = addToImageLibrary(fihdu, null);
                 if (libraryHDU != null) {
                     setSelectedInputImageHDU(libraryHDU);
+                    setInputImageView(KEYWORD_INIT_IMG);
                     success = true;
                 }
             }

--- a/src/main/java/fr/jmmc/oimaging/model/IRModel.java
+++ b/src/main/java/fr/jmmc/oimaging/model/IRModel.java
@@ -332,7 +332,7 @@ public final class IRModel {
                                                 final List<Role> roles) {
 
         final int nHdus = hdus.size();
-        logger.debug("addFitsImageHDUs: {} ImageHDUs from {}", nHdus, filename);
+        logger.info("addFitsImageHDUs: {} ImageHDUs from {}", nHdus, filename);
 
         hdus.forEach(hdu -> {
             // prepare images (negative values, padding, orientation):
@@ -534,9 +534,7 @@ public final class IRModel {
                 roles.add(Role.NO_ROLE);
             }
         }
-        if (logger.isDebugEnabled()) {
-            logger.debug("getHdusRoles[{}] : {}", oifitsFile.getAbsoluteFilePath(), roles);
-        }
+        logger.info("getHdusRoles[{}] : {}", oifitsFile.getAbsoluteFilePath(), roles);
         return roles;
     }
 
@@ -676,7 +674,6 @@ public final class IRModel {
         }
 
         // return an equivalent if there exists one
-        hdu.updateChecksum(); // first update the checksum to be able to checksum-compare
         final FitsImageHDU equivalentHDU = findInImageLibrary(hdu);
         if (equivalentHDU != null) {
             logger.info("HDU {} no added to image library because the equivalent HDU {} is already in the library.",
@@ -733,7 +730,6 @@ public final class IRModel {
             // name is available:
             logger.info("HDU_NAME '{}' is already used in imageLibrary, renamed to '{}'.", hdu.getHduName(), newName);
             hdu.setHduName(newName);
-            hdu.updateChecksum(); // update checksum after hduName update
         }
 
         // finally, add the hdu to the library
@@ -791,14 +787,10 @@ public final class IRModel {
      * return false if one of them has checksum = 0. The decision to compute expensively the checksum is on the caller.
      */
     private static boolean hduEquals(final FitsImageHDU first, final FitsImageHDU second) {
-        if (first == second) {
-            return true; // when they are the same reference or both null
-        } else if (first == null || second == null) {
-            return false; // when only one of them is null
-        } else {
-            return ((first.getChecksum() != 0) // only accepts computed checksums
-                    && (first.getChecksum() == second.getChecksum())); // compare the checksums
-        }
+        boolean equiv = FitsImageHDU.MATCHER.match(first, second);
+        logger.info("hdus {} and {} equiv: {}",
+                first == null ? "null" : first.getHduName(), second == null ? "null" : second.getHduName(), equiv);
+        return equiv;
     }
 
     // --- ServiceResult handling ---

--- a/src/main/java/fr/jmmc/oimaging/model/IRModel.java
+++ b/src/main/java/fr/jmmc/oimaging/model/IRModel.java
@@ -443,30 +443,35 @@ public final class IRModel {
 
         if (selectedResultList.size() == 1) {
             ServiceResult selectedResult = selectedResultList.get(0);
-            // copy of the file. because the input form will modify the oifitsfile.
-            OIFitsFile oifitsfile = new OIFitsFile(selectedResult.getOifitsFile());
 
-            // find last img HDU if needed, and if it exists in the oifitsfile
-            FitsImageHDU lastImgHdu = null;
-            if (useLastImgAsInit) {
-                List<Role> roles = getHdusRoles(oifitsfile);
-                for (int i = 0, s = roles.size(); i < s; i++) {
-                    switch (roles.get(i)) {
-                        case RESULT:
-                            lastImgHdu = oifitsfile.getFitsImageHDUs().get(i);
-                            break;
-                        default:
-                            break;
+            if (selectedResult.isValid()) {
+                // copy of the file. because the input form will modify the oifitsfile.
+                OIFitsFile oifitsfile = new OIFitsFile(selectedResult.getOifitsFile());
+
+                // find last img HDU if needed, and if it exists in the oifitsfile
+                FitsImageHDU lastImgHdu = null;
+                if (useLastImgAsInit) {
+                    List<Role> roles = getHdusRoles(oifitsfile);
+                    for (int i = 0, s = roles.size(); i < s; i++) {
+                        switch (roles.get(i)) {
+                            case RESULT:
+                                lastImgHdu = oifitsfile.getFitsImageHDUs().get(i);
+                                break;
+                            default:
+                                break;
+                        }
                     }
                 }
-            }
 
-            this.loadOIFits(oifitsfile);
+                this.loadOIFits(oifitsfile);
 
-            // if last img must becomes init image, set the equivalent of last img in library as init image.
-            // if lastImgHdu == null, it will correctly set init img to null.
-            if (useLastImgAsInit) {
-                setSelectedInputImageHDU(findInImageLibrary(lastImgHdu));
+                // if last img must becomes init image, set the equivalent of last img in library as init image.
+                // if lastImgHdu == null, it will correctly set init img to null.
+                if (useLastImgAsInit) {
+                    setSelectedInputImageHDU(findInImageLibrary(lastImgHdu));
+                }
+            } else {
+                success = false;
             }
         } else {
             success = false;

--- a/src/main/java/fr/jmmc/oimaging/model/IRModel.java
+++ b/src/main/java/fr/jmmc/oimaging/model/IRModel.java
@@ -155,7 +155,7 @@ public final class IRModel {
         // truncate file name to fix filepath too long crash
         // TODO: do this more cleanly by parsing suffixes and removing them
         final String trunkedFileName
-                = oiFitsFile.getFileName().substring(0, Math.min(oifitsFile.getFileName().length(), 80));
+                     = oiFitsFile.getFileName().substring(0, Math.min(oifitsFile.getFileName().length(), 80));
 
         final File tmpFile = FileUtils.getTempFile(trunkedFileName, ".export-" + exportCount + ".fits");
 
@@ -332,7 +332,7 @@ public final class IRModel {
                                                 final List<Role> roles) {
 
         final int nHdus = hdus.size();
-        logger.info("addFitsImageHDUs: {} ImageHDUs from {}", nHdus, filename);
+        logger.debug("addFitsImageHDUs: {} ImageHDUs from {}", nHdus, filename);
 
         hdus.forEach(hdu -> {
             // prepare images (negative values, padding, orientation):
@@ -400,7 +400,7 @@ public final class IRModel {
             }
         }
         // notify model change (to display model):
-        IRModelManager.getInstance().fireIRModelChanged(this, null);
+        IRModelManager.getInstance().fireIRModelChanged(this);
     }
 
     /**
@@ -421,7 +421,7 @@ public final class IRModel {
                 setSelectedRglPrioImageHdu(null);
             }
             // notify model change (to display model):
-            IRModelManager.getInstance().fireIRModelChanged(this, null);
+            IRModelManager.getInstance().fireIRModelChanged(this);
         }
         return removed;
     }
@@ -435,7 +435,7 @@ public final class IRModel {
      * @return true if exactly one result was selected, false otherwise.
      */
     public boolean loadResultAsInput(ServiceResult serviceResult, boolean useLastImgAsInit) {
-        boolean success = true;
+        boolean success = false;
 
         if (serviceResult.isValid()) {
             // copy of the file. because the input form will modify the oifitsfile.
@@ -463,10 +463,8 @@ public final class IRModel {
             if (useLastImgAsInit) {
                 setSelectedInputImageHDU(findInImageLibrary(lastImgHdu));
             }
-        } else {
-            success = false;
+            success = true;
         }
-
         return success;
     }
 
@@ -534,7 +532,9 @@ public final class IRModel {
                 roles.add(Role.NO_ROLE);
             }
         }
-        logger.info("getHdusRoles[{}] : {}", oifitsFile.getAbsoluteFilePath(), roles);
+        if (logger.isDebugEnabled()) {
+            logger.debug("getHdusRoles[{}] : {}", oifitsFile.getAbsoluteFilePath(), roles);
+        }
         return roles;
     }
 
@@ -886,7 +886,7 @@ public final class IRModel {
             setInputImageView(KEYWORD_INIT_IMG);
         }
         // notify model update
-        IRModelManager.getInstance().fireIRModelResultListChanged(this, null);
+        IRModelManager.getInstance().fireIRModelResultListChanged(this);
     }
 
     /** 
@@ -923,13 +923,13 @@ public final class IRModel {
     public void removeServiceResult(ServiceResult serviceResultToDelete) {
         getResultSets().remove(serviceResultToDelete);
         // notify model update
-        IRModelManager.getInstance().fireIRModelResultListChanged(this, null);
+        IRModelManager.getInstance().fireIRModelResultListChanged(this);
     }
 
     public void removeServiceResults(List<ServiceResult> selectedServicesList) {
         getResultSets().removeAll(selectedServicesList);
         // notify model update
-        IRModelManager.getInstance().fireIRModelResultListChanged(this, null);
+        IRModelManager.getInstance().fireIRModelResultListChanged(this);
     }
 
     private void loadLog(final ServiceResult serviceResult) {

--- a/src/main/java/fr/jmmc/oimaging/model/IRModel.java
+++ b/src/main/java/fr/jmmc/oimaging/model/IRModel.java
@@ -480,6 +480,11 @@ public final class IRModel {
         return success;
     }
 
+    /**
+     * Set the displayed image as initial image in the input form.
+     * Also place focus radio button on INIT_IMG.
+     * @return true when there was a displayed image, false otherwise.
+     */
     public boolean setAsInitImg() {
         boolean success = false;
         ViewerPanel viewerPanel = OImaging.getInstance().getMainPanel().getViewerPanelActive();

--- a/src/main/java/fr/jmmc/oimaging/model/IRModel.java
+++ b/src/main/java/fr/jmmc/oimaging/model/IRModel.java
@@ -486,17 +486,9 @@ public final class IRModel {
         if (viewerPanel != null) {
             FitsImageHDU fihdu = viewerPanel.getDisplayedFitsImageHDU();
             if (fihdu != null) {
-                FitsImageHDU libraryHDU = findInImageLibrary(fihdu);
+                FitsImageHDU libraryHDU = addToImageLibrary(fihdu, null);
                 if (libraryHDU != null) {
                     setSelectedInputImageHDU(libraryHDU);
-                    success = true;
-                } else {
-                    // the image is not necessarily in the library.
-                    // the user could have manually removed it.
-                    // it can have been refused after the run's result (see the strategies to refuse duplicate hdus)
-                    // anyway we must add it to the library, to be able to select it as init img.
-                    FitsImageHDU newLibraryHDU = addToImageLibrary(fihdu, null);
-                    setSelectedInputImageHDU(newLibraryHDU);
                     success = true;
                 }
             }

--- a/src/main/java/fr/jmmc/oimaging/model/IRModelEvent.java
+++ b/src/main/java/fr/jmmc/oimaging/model/IRModelEvent.java
@@ -14,20 +14,21 @@ import fr.jmmc.oiexplorer.core.model.event.GenericEvent;
  */
 public final class IRModelEvent extends GenericEvent<IRModelEventType, Object> {
 
-    private final IRModel irModel;
-
     /**
      * Public constructor dealing with an IR Model 
      * @param type event type
-     * @param subjectId optional related object id
      */
-    public IRModelEvent(final IRModelEventType type, final String subjectId, IRModel irModel) {
-        super(type, subjectId);
-        this.irModel = irModel;
+    public IRModelEvent(final IRModelEventType type) {
+        this(type, null);
     }
 
-    public IRModel getIrModel() {
-        return irModel;
+    /**
+     * Private constructor dealing with an IR Model 
+     * @param type event type
+     * @param subjectId optional related object id
+     */
+    private IRModelEvent(final IRModelEventType type, final String subjectId) {
+        super(type, subjectId);
     }
 
     /**
@@ -38,6 +39,7 @@ public final class IRModelEvent extends GenericEvent<IRModelEventType, Object> {
         final Object value;
         switch (getType()) {
             case IRMODEL_CHANGED:
+            case IRMODEL_RESULT_LIST_CHANGED:
                 value = IRModelManager.getInstance().getIRModel();
                 break;
             default:
@@ -49,4 +51,7 @@ public final class IRModelEvent extends GenericEvent<IRModelEventType, Object> {
     /* 
      * helper methods to get correct type depending on the event type 
      */
+    public IRModel getIrModel() {
+        return (IRModel) getSubjectValue();
+    }
 }

--- a/src/main/java/fr/jmmc/oimaging/model/IRModelEventType.java
+++ b/src/main/java/fr/jmmc/oimaging/model/IRModelEventType.java
@@ -10,8 +10,10 @@ public enum IRModelEventType {
 
     /** IRModel changed */
     IRMODEL_CHANGED,
-    /** last event type = ready */
-    READY,
+    /**
+     * Run
+     */
+    RUN,
     /** IRModel get a new service result */
     IRMODEL_RESULT_LIST_CHANGED
 }

--- a/src/main/java/fr/jmmc/oimaging/model/IRModelEventType.java
+++ b/src/main/java/fr/jmmc/oimaging/model/IRModelEventType.java
@@ -10,10 +10,8 @@ public enum IRModelEventType {
 
     /** IRModel changed */
     IRMODEL_CHANGED,
-    /**
-     * Run
-     */
-    RUN,
     /** IRModel get a new service result */
-    IRMODEL_RESULT_LIST_CHANGED
+    IRMODEL_RESULT_LIST_CHANGED,
+    /** Run action */
+    RUN
 }

--- a/src/main/java/fr/jmmc/oimaging/model/IRModelManager.java
+++ b/src/main/java/fr/jmmc/oimaging/model/IRModelManager.java
@@ -370,6 +370,11 @@ public final class IRModelManager {
         return success;
     }
 
+    /**
+     * Set the displayed image as initial image in the input form.
+     * Also place focus radio button on INIT_IMG.
+     * @return true when there was a displayed image, false otherwise.
+     */
     public boolean setAsInitImg() {
         boolean success = irModel.setAsInitImg();
         if (success) {

--- a/src/main/resources/fr/jmmc/oimaging/resource/ApplicationData.xml
+++ b/src/main/resources/fr/jmmc/oimaging/resource/ApplicationData.xml
@@ -16,7 +16,7 @@
     </company>
 
     <program name="OImaging" version="0.6.0 beta 11"/>
-    <compilation date="25/01/2022" compiler="JDK 1.8.0"/>
+    <compilation date="03/02/2022" compiler="JDK 1.8.0"/>
 
     <text>OImaging send your interferometric observation reduced data as OIFits files to standardized Image Reconstruction software.</text>
 
@@ -170,7 +170,7 @@
 
     <releasenotes>
         <release version="0.6.0">
-            <pubDate>Tue, 25 Jan 2022 16:00:00 GMT</pubDate>
+            <pubDate>Tue, 03 Feb 2022 16:00:00 GMT</pubDate>
             <prerelease version="0.6.0 beta 11">
                 <change type="FEATURE" url="https://github.com/JMMC-OpenDev/oimaging/issues/69" >Added buttons to fill the input form with a selected result</change>
                 <change type="FEATURE" url="https://github.com/JMMC-OpenDev/oimaging/issues/21">Improved GUI to adopt two views Input &amp; Results</change>

--- a/src/main/resources/fr/jmmc/oimaging/resource/ApplicationData.xml
+++ b/src/main/resources/fr/jmmc/oimaging/resource/ApplicationData.xml
@@ -172,6 +172,7 @@
         <release version="0.6.0">
             <pubDate>Tue, 25 Jan 2022 16:00:00 GMT</pubDate>
             <prerelease version="0.6.0 beta 11">
+                <change type="FEATURE" url="https://github.com/JMMC-OpenDev/oimaging/issues/69" >Added buttons to fill the input form with a selected result</change>
                 <change type="FEATURE" url="https://github.com/JMMC-OpenDev/oimaging/issues/21">Improved GUI to adopt two views Input &amp; Results</change>
             </prerelease>
             <prerelease version="0.6.0 beta 10">


### PR DESCRIPTION
Related Issue https://github.com/JMMC-OpenDev/oimaging/issues/69
Related OITOOLS PR https://github.com/JMMC-OpenDev/oitools/pull/48

Add four buttons to the action panel in result tab.
- Run more iterations
- Load as input
- Load as input with last img
- Set as init img

The major update is the new flow of data in the software. Now a result can be selected by the user and sent to fill the input form. Previously data from results never went outside results. This PR goes with the OITOOLS PR which implements the copy of OIFITSFILE, needed to use the data of a result without altering it.

Secondary, three actions have been created for the new buttons. to load the result in input, the result oifitsfile is copied, then given to the existing function loadOIFitsFile from IRModel.

The new button provoke more duplicates in the image library than before, the issue alternative checksum https://github.com/JMMC-OpenDev/oimaging/issues/82 has been created to answer it.

The copy of oifitsfile from result to input form has a problem, because the results do not keep oifits data identical. Not only they add some OI TABLE but also they remove some OI TABLE. My local branch https://github.com/buthanoid/oimaging/tree/fix-oifits-data-missing-in-result-2 is a proposal to resolve this problem for the release. 

Each run adds a suffix to the filename, since we now use results as inputs, filename can grow large. a small fix has been added to prevent this filename from growing too much (which was buggy). A clean solution is left as a TODO.