### PR TITLE
removed execution log capture focus when result invalid

### DIFF
--- a/src/main/java/fr/jmmc/oimaging/gui/ViewerPanel.java
+++ b/src/main/java/fr/jmmc/oimaging/gui/ViewerPanel.java
@@ -314,9 +314,10 @@ public class ViewerPanel extends javax.swing.JPanel implements ChangeListener {
 
                 displayImage(imageHdus, imageHDU);
                 displayOiFitsAndParams(oifitsFile, target);
-            } else {
-                lastResultPanel = jPanelLogViewer;
             }
+            /*else {
+                lastResultPanel = jPanelLogViewer;
+            }*/
 
             setTabMode(SHOW_MODE.RESULT);
         }


### PR DESCRIPTION
Resolving issue https://github.com/JMMC-OpenDev/oimaging/issues/80

Only remove one line marking "execution log" as the last selected tab