### PR TITLE
hide FLUX & FLUXERR in GUI issue #26

### DIFF
--- a/src/main/java/fr/jmmc/oimaging/gui/SoftwareSettingsPanel.java
+++ b/src/main/java/fr/jmmc/oimaging/gui/SoftwareSettingsPanel.java
@@ -861,6 +861,7 @@ public class SoftwareSettingsPanel extends javax.swing.JPanel {
         if (guiService != null && !guiService.equals(modelSoftware)) {
             changedService = !modelSoftware.isCompatibleParams(guiService);
             irModel.setSelectedService(guiService);
+            irModel.initSpecificParams(false);
             changed = true;
         }
 

--- a/src/main/java/fr/jmmc/oimaging/model/IRModel.java
+++ b/src/main/java/fr/jmmc/oimaging/model/IRModel.java
@@ -171,8 +171,8 @@ public final class IRModel {
     }
 
     private void resetOIFits() {
-        // we set default service parameters values
-        loadOIFits(new OIFitsFile(OIFitsStandard.VERSION_1), true);
+        loadOIFits(new OIFitsFile(OIFitsStandard.VERSION_1));
+        initSpecificParams(true); // force reset of specific parameters values
     }
 
     /**
@@ -190,19 +190,9 @@ public final class IRModel {
 
     /**
      * Load the OiData tables of the model (oifits file, targets).
-     *
      * @param oifitsFile OIFitsFile to use. Caution: this OIFitsFile can be altered, better give a copy.
      */
     private void loadOIFits(final OIFitsFile oifitsFile) {
-        loadOIFits(oifitsFile, false);
-    }
-
-    /**
-     * Load the OiData tables of the model (oifits file, targets).
-     * @param oifitsFile OIFitsFile to use. Caution: this OIFitsFile can be altered, better give a copy.
-     * @param applyServiceDefaults boolean to set default service parameters values, or not
-     */
-    private void loadOIFits(final OIFitsFile oifitsFile, final boolean applyServiceDefaults) {
         // change current model immediately:
         this.oifitsFile = oifitsFile;
 
@@ -271,23 +261,9 @@ public final class IRModel {
         setSelectedRglPrioImageHdu(rglHduEquiv);
 
         // try to guess and set service
-        final Service service = ServiceList.getServiceFromOIFitsFile(oifitsFile);
-        if (service == null) {
-            // avoid null service
-            if (getSelectedService() == null) {
-                // Note: setSelectedService() calls initSpecificParams():
-                setSelectedService(ServiceList.getPreferedService(), applyServiceDefaults);
-            } else {
-                initSpecificParams(false);
-            }
-        } else {
-            if ((getSelectedService() == null) || (!service.getProgram().equals(getSelectedService().getProgram()))) {
-                // Note: setSelectedService() calls initSpecificParams():
-                setSelectedService(service);
-            } else {
-                initSpecificParams(false);
-            }
-        }
+        final Service oifitsFileService = ServiceList.getServiceFromOIFitsFile(oifitsFile);
+        setSelectedService(oifitsFileService == null ? ServiceList.getPreferedService() : oifitsFileService);
+        initSpecificParams(false); // add keywords relating to the selected service
 
         // cleaning all output params as they are meaningless in the input form
         // it must be done AFTER role computation (it uses output params)
@@ -996,23 +972,12 @@ public final class IRModel {
     }
 
     /**
-     * Set the service, and does not apply default parameters values.
+     * Set the service
      *
      * @param selectedService service to set
      */
     public void setSelectedService(final Service selectedService) {
-        setSelectedService(selectedService, false);
-    }
-
-    /**
-     * Set the service, and apply default parameters values or not.
-     *
-     * @param selectedService service to set
-     * @param applyDefaults boolean saying if we apply default parameters values or not.
-     */
-    public void setSelectedService(final Service selectedService, final boolean applyDefaults) {
         this.selectedService = selectedService;
-        initSpecificParams(applyDefaults);
     }
 
     public void initSpecificParams(final boolean applyDefaults) {

--- a/src/main/java/fr/jmmc/oimaging/model/IRModel.java
+++ b/src/main/java/fr/jmmc/oimaging/model/IRModel.java
@@ -171,7 +171,8 @@ public final class IRModel {
     }
 
     private void resetOIFits() {
-        loadOIFits(new OIFitsFile(OIFitsStandard.VERSION_1));
+        // we set default service parameters values
+        loadOIFits(new OIFitsFile(OIFitsStandard.VERSION_1), true);
     }
 
     /**
@@ -189,9 +190,19 @@ public final class IRModel {
 
     /**
      * Load the OiData tables of the model (oifits file, targets).
+     *
      * @param oifitsFile OIFitsFile to use. Caution: this OIFitsFile can be altered, better give a copy.
      */
     private void loadOIFits(final OIFitsFile oifitsFile) {
+        loadOIFits(oifitsFile, false);
+    }
+
+    /**
+     * Load the OiData tables of the model (oifits file, targets).
+     * @param oifitsFile OIFitsFile to use. Caution: this OIFitsFile can be altered, better give a copy.
+     * @param applyServiceDefaults boolean to set default service parameters values, or not
+     */
+    private void loadOIFits(final OIFitsFile oifitsFile, final boolean applyServiceDefaults) {
         // change current model immediately:
         this.oifitsFile = oifitsFile;
 
@@ -265,7 +276,7 @@ public final class IRModel {
             // avoid null service
             if (getSelectedService() == null) {
                 // Note: setSelectedService() calls initSpecificParams():
-                setSelectedService(ServiceList.getPreferedService());
+                setSelectedService(ServiceList.getPreferedService(), applyServiceDefaults);
             } else {
                 initSpecificParams(false);
             }
@@ -984,9 +995,24 @@ public final class IRModel {
         return selectedService;
     }
 
+    /**
+     * Set the service, and does not apply default parameters values.
+     *
+     * @param selectedService service to set
+     */
     public void setSelectedService(final Service selectedService) {
+        setSelectedService(selectedService, false);
+    }
+
+    /**
+     * Set the service, and apply default parameters values or not.
+     *
+     * @param selectedService service to set
+     * @param applyDefaults boolean saying if we apply default parameters values or not.
+     */
+    public void setSelectedService(final Service selectedService, final boolean applyDefaults) {
         this.selectedService = selectedService;
-        initSpecificParams(false);
+        initSpecificParams(applyDefaults);
     }
 
     public void initSpecificParams(final boolean applyDefaults) {

--- a/src/main/java/fr/jmmc/oimaging/services/software/WisardInputParam.java
+++ b/src/main/java/fr/jmmc/oimaging/services/software/WisardInputParam.java
@@ -77,7 +77,7 @@ public final class WisardInputParam extends SoftwareInputParam {
         if (applyDefaults) {
             // specific default values for WISARD:
             params.setRglWgt(1E-4);
-            params.setFluxErr(1E-6);
+            params.setFluxErr(1E-4);
         }
 
         // change table default:


### PR DESCRIPTION
- Set WISARD FLUX_ERR default value to 10e-4 instead of 10e-6
- Ask for applying default parameters values when IRModel is reset. Unless this, WISARD FLUX_ERR default to 10e-4 is not applied when OImaging is started, leaving general default FLUX_ERR value 10e-2

Associated to OImaging issue https://github.com/JMMC-OpenDev/oimaging/issues/26
