### PR TITLE
vis t3 string values with combobox instead of boolean with checkboxes

### DIFF
--- a/src/main/java/fr/jmmc/oimaging/gui/MainPanel.form
+++ b/src/main/java/fr/jmmc/oimaging/gui/MainPanel.form
@@ -111,54 +111,6 @@
 
                           <Layout class="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout"/>
                           <SubComponents>
-                            <Component class="javax.swing.JCheckBox" name="jCheckBoxUseVis">
-                              <Properties>
-                                <Property name="text" type="java.lang.String" value="VIS"/>
-                                <Property name="toolTipText" type="java.lang.String" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
-                                  <Connection code="getTooltip(ImageOiConstants.KEYWORD_USE_VIS)" type="code"/>
-                                </Property>
-                              </Properties>
-                              <Events>
-                                <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="jCheckBoxActionPerformed"/>
-                              </Events>
-                              <Constraints>
-                                <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
-                                  <GridBagConstraints gridX="0" gridY="3" gridWidth="1" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="0" insetsBottom="0" insetsRight="0" anchor="10" weightX="0.1" weightY="0.0"/>
-                                </Constraint>
-                              </Constraints>
-                            </Component>
-                            <Component class="javax.swing.JCheckBox" name="jCheckBoxUseVis2">
-                              <Properties>
-                                <Property name="text" type="java.lang.String" value="VIS2"/>
-                                <Property name="toolTipText" type="java.lang.String" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
-                                  <Connection code="getTooltip(ImageOiConstants.KEYWORD_USE_VIS2)" type="code"/>
-                                </Property>
-                              </Properties>
-                              <Events>
-                                <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="jCheckBoxActionPerformed"/>
-                              </Events>
-                              <Constraints>
-                                <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
-                                  <GridBagConstraints gridX="1" gridY="3" gridWidth="1" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="0" insetsBottom="0" insetsRight="0" anchor="10" weightX="0.1" weightY="0.0"/>
-                                </Constraint>
-                              </Constraints>
-                            </Component>
-                            <Component class="javax.swing.JCheckBox" name="jCheckBoxUseT3">
-                              <Properties>
-                                <Property name="text" type="java.lang.String" value="T3"/>
-                                <Property name="toolTipText" type="java.lang.String" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
-                                  <Connection code="getTooltip(ImageOiConstants.KEYWORD_USE_T3)" type="code"/>
-                                </Property>
-                              </Properties>
-                              <Events>
-                                <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="jCheckBoxActionPerformed"/>
-                              </Events>
-                              <Constraints>
-                                <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
-                                  <GridBagConstraints gridX="2" gridY="3" gridWidth="1" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="0" insetsBottom="0" insetsRight="0" anchor="10" weightX="0.1" weightY="0.0"/>
-                                </Constraint>
-                              </Constraints>
-                            </Component>
                             <Container class="javax.swing.JPanel" name="jPanelTarget">
                               <Constraints>
                                 <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
@@ -334,6 +286,89 @@
                                 </Constraint>
                               </Constraints>
                             </Component>
+                            <Container class="javax.swing.JPanel" name="jPanel1">
+                              <Constraints>
+                                <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+                                  <GridBagConstraints gridX="0" gridY="3" gridWidth="3" gridHeight="1" fill="2" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="0" insetsBottom="0" insetsRight="0" anchor="10" weightX="0.0" weightY="0.0"/>
+                                </Constraint>
+                              </Constraints>
+
+                              <Layout class="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout"/>
+                              <SubComponents>
+                                <Component class="javax.swing.JComboBox" name="jComboBoxUseVis">
+                                  <Properties>
+                                    <Property name="model" type="javax.swing.ComboBoxModel" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
+                                      <Connection code="new DefaultComboBoxModel&lt;String&gt;(fr.jmmc.oitools.image.ImageOiInputParam.VIS2_T3_VALUES)" type="code"/>
+                                    </Property>
+                                  </Properties>
+                                  <Events>
+                                    <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="jComboBoxUseVisActionPerformed"/>
+                                  </Events>
+                                  <AuxValues>
+                                    <AuxValue name="JavaCodeGenerator_TypeParameters" type="java.lang.String" value="&lt;String&gt;"/>
+                                  </AuxValues>
+                                  <Constraints>
+                                    <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+                                      <GridBagConstraints gridX="1" gridY="0" gridWidth="1" gridHeight="1" fill="2" ipadX="0" ipadY="0" insetsTop="2" insetsLeft="2" insetsBottom="2" insetsRight="2" anchor="10" weightX="0.2" weightY="0.0"/>
+                                    </Constraint>
+                                  </Constraints>
+                                </Component>
+                                <Component class="javax.swing.JCheckBox" name="jCheckBoxUseVis2">
+                                  <Properties>
+                                    <Property name="text" type="java.lang.String" value="VIS2"/>
+                                    <Property name="toolTipText" type="java.lang.String" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
+                                      <Connection code="getTooltip(ImageOiConstants.KEYWORD_USE_VIS2)" type="code"/>
+                                    </Property>
+                                  </Properties>
+                                  <Events>
+                                    <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="jCheckBoxActionPerformed"/>
+                                  </Events>
+                                  <Constraints>
+                                    <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+                                      <GridBagConstraints gridX="2" gridY="0" gridWidth="1" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="2" insetsLeft="2" insetsBottom="2" insetsRight="2" anchor="10" weightX="0.1" weightY="0.0"/>
+                                    </Constraint>
+                                  </Constraints>
+                                </Component>
+                                <Component class="javax.swing.JComboBox" name="jComboBoxUseT3">
+                                  <Properties>
+                                    <Property name="model" type="javax.swing.ComboBoxModel" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
+                                      <Connection code="new DefaultComboBoxModel&lt;String&gt;(fr.jmmc.oitools.image.ImageOiInputParam.VIS2_T3_VALUES)" type="code"/>
+                                    </Property>
+                                  </Properties>
+                                  <Events>
+                                    <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="jComboBoxUseT3ActionPerformed"/>
+                                  </Events>
+                                  <AuxValues>
+                                    <AuxValue name="JavaCodeGenerator_TypeParameters" type="java.lang.String" value="&lt;String&gt;"/>
+                                  </AuxValues>
+                                  <Constraints>
+                                    <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+                                      <GridBagConstraints gridX="4" gridY="0" gridWidth="1" gridHeight="1" fill="2" ipadX="0" ipadY="0" insetsTop="2" insetsLeft="2" insetsBottom="2" insetsRight="2" anchor="10" weightX="0.2" weightY="0.0"/>
+                                    </Constraint>
+                                  </Constraints>
+                                </Component>
+                                <Component class="javax.swing.JLabel" name="jLabelUseVis">
+                                  <Properties>
+                                    <Property name="text" type="java.lang.String" value="VIS"/>
+                                  </Properties>
+                                  <Constraints>
+                                    <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+                                      <GridBagConstraints gridX="0" gridY="0" gridWidth="1" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="2" insetsLeft="2" insetsBottom="2" insetsRight="2" anchor="10" weightX="0.0" weightY="0.0"/>
+                                    </Constraint>
+                                  </Constraints>
+                                </Component>
+                                <Component class="javax.swing.JLabel" name="jLabelUseT3">
+                                  <Properties>
+                                    <Property name="text" type="java.lang.String" value="T3"/>
+                                  </Properties>
+                                  <Constraints>
+                                    <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+                                      <GridBagConstraints gridX="3" gridY="0" gridWidth="1" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="2" insetsLeft="2" insetsBottom="2" insetsRight="2" anchor="10" weightX="0.0" weightY="0.0"/>
+                                    </Constraint>
+                                  </Constraints>
+                                </Component>
+                              </SubComponents>
+                            </Container>
                           </SubComponents>
                         </Container>
                         <Component class="fr.jmmc.oimaging.gui.SoftwareSettingsPanel" name="softwareSettingsPanel">
@@ -468,7 +503,7 @@
                         </Constraint>
                       </Constraints>
 
-                      <Layout class="org.netbeans.modules.form.compat2.layouts.DesignFlowLayout"/>
+                      <Layout class="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout"/>
                       <SubComponents>
                         <Component class="javax.swing.JButton" name="jButtonRunMoreIterations">
                           <Properties>
@@ -477,6 +512,11 @@
                             </Property>
                             <Property name="text" type="java.lang.String" value="Run more iterations"/>
                           </Properties>
+                          <Constraints>
+                            <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+                              <GridBagConstraints gridX="-1" gridY="-1" gridWidth="1" gridHeight="1" fill="2" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="0" insetsBottom="0" insetsRight="0" anchor="10" weightX="0.0" weightY="0.0"/>
+                            </Constraint>
+                          </Constraints>
                         </Component>
                         <Component class="javax.swing.JButton" name="jButtonLoadAsInput">
                           <Properties>
@@ -488,6 +528,11 @@
                               <Connection code="LoadResultAsInputAction.USE_INIT_IMG_AS_INIT" type="code"/>
                             </Property>
                           </Properties>
+                          <Constraints>
+                            <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+                              <GridBagConstraints gridX="0" gridY="1" gridWidth="1" gridHeight="1" fill="2" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="0" insetsBottom="0" insetsRight="0" anchor="10" weightX="0.0" weightY="0.0"/>
+                            </Constraint>
+                          </Constraints>
                         </Component>
                         <Component class="javax.swing.JButton" name="jButtonLoadAsInputWithLastImg">
                           <Properties>
@@ -499,12 +544,22 @@
                               <Connection code="LoadResultAsInputAction.USE_LAST_IMG_AS_INIT" type="code"/>
                             </Property>
                           </Properties>
+                          <Constraints>
+                            <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+                              <GridBagConstraints gridX="0" gridY="2" gridWidth="1" gridHeight="1" fill="2" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="0" insetsBottom="0" insetsRight="0" anchor="10" weightX="0.0" weightY="0.0"/>
+                            </Constraint>
+                          </Constraints>
                         </Component>
                         <Component class="javax.swing.JButton" name="jButtonExportOIFits">
                           <Properties>
                             <Property name="text" type="java.lang.String" value="Save OIFitsFile"/>
                             <Property name="name" type="java.lang.String" value="jButtonExportOIFits" noResource="true"/>
                           </Properties>
+                          <Constraints>
+                            <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+                              <GridBagConstraints gridX="0" gridY="3" gridWidth="1" gridHeight="1" fill="2" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="0" insetsBottom="0" insetsRight="0" anchor="10" weightX="0.0" weightY="0.0"/>
+                            </Constraint>
+                          </Constraints>
                         </Component>
                       </SubComponents>
                     </Container>

--- a/src/main/java/fr/jmmc/oimaging/gui/MainPanel.form
+++ b/src/main/java/fr/jmmc/oimaging/gui/MainPanel.form
@@ -298,7 +298,7 @@
                                 <Component class="javax.swing.JComboBox" name="jComboBoxUseVis">
                                   <Properties>
                                     <Property name="model" type="javax.swing.ComboBoxModel" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
-                                      <Connection code="new DefaultComboBoxModel&lt;String&gt;(fr.jmmc.oitools.image.ImageOiInputParam.VIS2_T3_VALUES)" type="code"/>
+                                      <Connection code="new DefaultComboBoxModel&lt;String&gt;(ImageOiInputParam.USE_VALUES)" type="code"/>
                                     </Property>
                                   </Properties>
                                   <Events>
@@ -332,7 +332,7 @@
                                 <Component class="javax.swing.JComboBox" name="jComboBoxUseT3">
                                   <Properties>
                                     <Property name="model" type="javax.swing.ComboBoxModel" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
-                                      <Connection code="new DefaultComboBoxModel&lt;String&gt;(fr.jmmc.oitools.image.ImageOiInputParam.VIS2_T3_VALUES)" type="code"/>
+                                      <Connection code="new DefaultComboBoxModel&lt;String&gt;(ImageOiInputParam.USE_VALUES)" type="code"/>
                                     </Property>
                                   </Properties>
                                   <Events>

--- a/src/main/java/fr/jmmc/oimaging/gui/MainPanel.java
+++ b/src/main/java/fr/jmmc/oimaging/gui/MainPanel.java
@@ -46,6 +46,7 @@ import java.beans.PropertyChangeListener;
 import java.util.LinkedList;
 import java.util.List;
 import javax.swing.Action;
+import javax.swing.DefaultComboBoxModel;
 import javax.swing.JButton;
 import javax.swing.JFrame;
 import javax.swing.JSlider;
@@ -345,9 +346,6 @@ public class MainPanel extends javax.swing.JPanel implements IRModelEventListene
         jScrollPaneInputForm = new javax.swing.JScrollPane();
         jPanelInputForm = new javax.swing.JPanel();
         jPanelDataSelection = new javax.swing.JPanel();
-        jCheckBoxUseVis = new javax.swing.JCheckBox();
-        jCheckBoxUseVis2 = new javax.swing.JCheckBox();
-        jCheckBoxUseT3 = new javax.swing.JCheckBox();
         jPanelTarget = new javax.swing.JPanel();
         jComboBoxTarget = new javax.swing.JComboBox();
         jLabelTarget = new javax.swing.JLabel();
@@ -360,6 +358,12 @@ public class MainPanel extends javax.swing.JPanel implements IRModelEventListene
         jFormattedTextFieldWaveMin = new javax.swing.JFormattedTextField();
         jFormattedTextFieldWaveMax = new javax.swing.JFormattedTextField();
         jLabelOifitsFile = new javax.swing.JLabel();
+        jPanel1 = new javax.swing.JPanel();
+        jComboBoxUseVis = new javax.swing.JComboBox<>();
+        jCheckBoxUseVis2 = new javax.swing.JCheckBox();
+        jComboBoxUseT3 = new javax.swing.JComboBox<>();
+        jLabelUseVis = new javax.swing.JLabel();
+        jLabelUseT3 = new javax.swing.JLabel();
         softwareSettingsPanel = new fr.jmmc.oimaging.gui.SoftwareSettingsPanel();
         jPanelExecutionLog = new javax.swing.JPanel();
         jButtonRun = new javax.swing.JButton();
@@ -405,45 +409,6 @@ public class MainPanel extends javax.swing.JPanel implements IRModelEventListene
 
         jPanelDataSelection.setBorder(javax.swing.BorderFactory.createTitledBorder("Data selection"));
         jPanelDataSelection.setLayout(new java.awt.GridBagLayout());
-
-        jCheckBoxUseVis.setText("VIS");
-        jCheckBoxUseVis.setToolTipText(getTooltip(ImageOiConstants.KEYWORD_USE_VIS));
-        jCheckBoxUseVis.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                jCheckBoxActionPerformed(evt);
-            }
-        });
-        gridBagConstraints = new java.awt.GridBagConstraints();
-        gridBagConstraints.gridx = 0;
-        gridBagConstraints.gridy = 3;
-        gridBagConstraints.weightx = 0.1;
-        jPanelDataSelection.add(jCheckBoxUseVis, gridBagConstraints);
-
-        jCheckBoxUseVis2.setText("VIS2");
-        jCheckBoxUseVis2.setToolTipText(getTooltip(ImageOiConstants.KEYWORD_USE_VIS2));
-        jCheckBoxUseVis2.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                jCheckBoxActionPerformed(evt);
-            }
-        });
-        gridBagConstraints = new java.awt.GridBagConstraints();
-        gridBagConstraints.gridx = 1;
-        gridBagConstraints.gridy = 3;
-        gridBagConstraints.weightx = 0.1;
-        jPanelDataSelection.add(jCheckBoxUseVis2, gridBagConstraints);
-
-        jCheckBoxUseT3.setText("T3");
-        jCheckBoxUseT3.setToolTipText(getTooltip(ImageOiConstants.KEYWORD_USE_T3));
-        jCheckBoxUseT3.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                jCheckBoxActionPerformed(evt);
-            }
-        });
-        gridBagConstraints = new java.awt.GridBagConstraints();
-        gridBagConstraints.gridx = 2;
-        gridBagConstraints.gridy = 3;
-        gridBagConstraints.weightx = 0.1;
-        jPanelDataSelection.add(jCheckBoxUseT3, gridBagConstraints);
 
         jPanelTarget.setLayout(new java.awt.GridBagLayout());
 
@@ -580,6 +545,71 @@ public class MainPanel extends javax.swing.JPanel implements IRModelEventListene
         gridBagConstraints.weightx = 0.1;
         jPanelDataSelection.add(jLabelOifitsFile, gridBagConstraints);
 
+        jPanel1.setLayout(new java.awt.GridBagLayout());
+
+        jComboBoxUseVis.setModel(new DefaultComboBoxModel<String>(fr.jmmc.oitools.image.ImageOiInputParam.VIS2_T3_VALUES));
+        jComboBoxUseVis.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                jComboBoxUseVisActionPerformed(evt);
+            }
+        });
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.gridx = 1;
+        gridBagConstraints.gridy = 0;
+        gridBagConstraints.fill = java.awt.GridBagConstraints.HORIZONTAL;
+        gridBagConstraints.weightx = 0.2;
+        gridBagConstraints.insets = new java.awt.Insets(2, 2, 2, 2);
+        jPanel1.add(jComboBoxUseVis, gridBagConstraints);
+
+        jCheckBoxUseVis2.setText("VIS2");
+        jCheckBoxUseVis2.setToolTipText(getTooltip(ImageOiConstants.KEYWORD_USE_VIS2));
+        jCheckBoxUseVis2.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                jCheckBoxActionPerformed(evt);
+            }
+        });
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.gridx = 2;
+        gridBagConstraints.gridy = 0;
+        gridBagConstraints.weightx = 0.1;
+        gridBagConstraints.insets = new java.awt.Insets(2, 2, 2, 2);
+        jPanel1.add(jCheckBoxUseVis2, gridBagConstraints);
+
+        jComboBoxUseT3.setModel(new DefaultComboBoxModel<String>(fr.jmmc.oitools.image.ImageOiInputParam.VIS2_T3_VALUES));
+        jComboBoxUseT3.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                jComboBoxUseT3ActionPerformed(evt);
+            }
+        });
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.gridx = 4;
+        gridBagConstraints.gridy = 0;
+        gridBagConstraints.fill = java.awt.GridBagConstraints.HORIZONTAL;
+        gridBagConstraints.weightx = 0.2;
+        gridBagConstraints.insets = new java.awt.Insets(2, 2, 2, 2);
+        jPanel1.add(jComboBoxUseT3, gridBagConstraints);
+
+        jLabelUseVis.setText("VIS");
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.gridx = 0;
+        gridBagConstraints.gridy = 0;
+        gridBagConstraints.insets = new java.awt.Insets(2, 2, 2, 2);
+        jPanel1.add(jLabelUseVis, gridBagConstraints);
+
+        jLabelUseT3.setText("T3");
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.gridx = 3;
+        gridBagConstraints.gridy = 0;
+        gridBagConstraints.insets = new java.awt.Insets(2, 2, 2, 2);
+        jPanel1.add(jLabelUseT3, gridBagConstraints);
+
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.gridx = 0;
+        gridBagConstraints.gridy = 3;
+        gridBagConstraints.gridwidth = 3;
+        gridBagConstraints.fill = java.awt.GridBagConstraints.HORIZONTAL;
+        jPanelDataSelection.add(jPanel1, gridBagConstraints);
+
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.gridx = 0;
         gridBagConstraints.gridy = 0;
@@ -655,10 +685,7 @@ public class MainPanel extends javax.swing.JPanel implements IRModelEventListene
         jButtonRunMoreIterations.setAction(ActionRegistrar.getInstance().get(fr.jmmc.oimaging.gui.action.RunMoreIterationsAction.CLASS_NAME, fr.jmmc.oimaging.gui.action.RunMoreIterationsAction.ACTION_NAME));
         jButtonRunMoreIterations.setText("Run more iterations");
         gridBagConstraints = new java.awt.GridBagConstraints();
-        gridBagConstraints.gridx = 0;
-        gridBagConstraints.gridy = 0;
         gridBagConstraints.fill = java.awt.GridBagConstraints.HORIZONTAL;
-        gridBagConstraints.insets = new java.awt.Insets(2, 2, 2, 2);
         jPanelResultsActions.add(jButtonRunMoreIterations, gridBagConstraints);
 
         jButtonLoadAsInput.setAction(ActionRegistrar.getInstance().get(fr.jmmc.oimaging.gui.action.LoadResultAsInputAction.CLASS_NAME, fr.jmmc.oimaging.gui.action.LoadResultAsInputAction.ACTION_NAME));
@@ -668,7 +695,6 @@ public class MainPanel extends javax.swing.JPanel implements IRModelEventListene
         gridBagConstraints.gridx = 0;
         gridBagConstraints.gridy = 1;
         gridBagConstraints.fill = java.awt.GridBagConstraints.HORIZONTAL;
-        gridBagConstraints.insets = new java.awt.Insets(2, 2, 2, 2);
         jPanelResultsActions.add(jButtonLoadAsInput, gridBagConstraints);
 
         jButtonLoadAsInputWithLastImg.setAction(ActionRegistrar.getInstance().get(fr.jmmc.oimaging.gui.action.LoadResultAsInputAction.CLASS_NAME, fr.jmmc.oimaging.gui.action.LoadResultAsInputAction.ACTION_NAME));
@@ -678,7 +704,6 @@ public class MainPanel extends javax.swing.JPanel implements IRModelEventListene
         gridBagConstraints.gridx = 0;
         gridBagConstraints.gridy = 2;
         gridBagConstraints.fill = java.awt.GridBagConstraints.HORIZONTAL;
-        gridBagConstraints.insets = new java.awt.Insets(2, 2, 2, 2);
         jPanelResultsActions.add(jButtonLoadAsInputWithLastImg, gridBagConstraints);
 
         jButtonExportOIFits.setText("Save OIFitsFile");
@@ -687,7 +712,6 @@ public class MainPanel extends javax.swing.JPanel implements IRModelEventListene
         gridBagConstraints.gridx = 0;
         gridBagConstraints.gridy = 3;
         gridBagConstraints.fill = java.awt.GridBagConstraints.HORIZONTAL;
-        gridBagConstraints.insets = new java.awt.Insets(2, 2, 2, 2);
         jPanelResultsActions.add(jButtonExportOIFits, gridBagConstraints);
 
         gridBagConstraints = new java.awt.GridBagConstraints();
@@ -760,6 +784,14 @@ public class MainPanel extends javax.swing.JPanel implements IRModelEventListene
             viewerPanelResults.displayGrid(jTablePanel.getSelectedRows());
         }
     }//GEN-LAST:event_jButtonCompareActionPerformed
+
+    private void jComboBoxUseVisActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jComboBoxUseVisActionPerformed
+        updateModel();
+    }//GEN-LAST:event_jComboBoxUseVisActionPerformed
+
+    private void jComboBoxUseT3ActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jComboBoxUseT3ActionPerformed
+        updateModel();
+    }//GEN-LAST:event_jComboBoxUseT3ActionPerformed
 
     public void deleteSelectedRows() {
         final int nSelected = jTablePanel.getSelectedRowsCount();
@@ -843,10 +875,10 @@ public class MainPanel extends javax.swing.JPanel implements IRModelEventListene
     private javax.swing.JButton jButtonLoadData;
     private javax.swing.JButton jButtonRun;
     private javax.swing.JButton jButtonRunMoreIterations;
-    private javax.swing.JCheckBox jCheckBoxUseT3;
-    private javax.swing.JCheckBox jCheckBoxUseVis;
     private javax.swing.JCheckBox jCheckBoxUseVis2;
     private javax.swing.JComboBox jComboBoxTarget;
+    private javax.swing.JComboBox<String> jComboBoxUseT3;
+    private javax.swing.JComboBox<String> jComboBoxUseVis;
     private javax.swing.JEditorPane jEditorPane;
     private javax.swing.JFormattedTextField jFormattedTextFieldWaveMax;
     private javax.swing.JFormattedTextField jFormattedTextFieldWaveMin;
@@ -854,8 +886,11 @@ public class MainPanel extends javax.swing.JPanel implements IRModelEventListene
     private javax.swing.JLabel jLabelTabInput;
     private javax.swing.JLabel jLabelTabResults;
     private javax.swing.JLabel jLabelTarget;
+    private javax.swing.JLabel jLabelUseT3;
+    private javax.swing.JLabel jLabelUseVis;
     private javax.swing.JLabel jLabelWaveMax;
     private javax.swing.JLabel jLabelWaveMin;
+    private javax.swing.JPanel jPanel1;
     private javax.swing.JPanel jPanelDataSelection;
     private javax.swing.JPanel jPanelExecutionLog;
     private javax.swing.JPanel jPanelInputForm;
@@ -960,10 +995,10 @@ public class MainPanel extends javax.swing.JPanel implements IRModelEventListene
         }
 
         // observables
-        mFlag = params.useVis();
-        wFlag = jCheckBoxUseVis.isSelected();
-        if (mFlag != wFlag) {
-            params.useVis(wFlag);
+        mString = params.useVis();
+        wString = (String) jComboBoxUseVis.getSelectedItem();
+        if (mString != null && !mString.equals(wString)) {
+            params.useVis(wString);
             changed = true;
         }
 
@@ -974,10 +1009,10 @@ public class MainPanel extends javax.swing.JPanel implements IRModelEventListene
             changed = true;
         }
 
-        mFlag = params.useT3();
-        wFlag = jCheckBoxUseT3.isSelected();
-        if (mFlag != wFlag) {
-            params.useT3(wFlag);
+        mString = params.useT3();
+        wString = (String) jComboBoxUseT3.getSelectedItem();
+        if (mString != null && !mString.equals(wString)) {
+            params.useT3(wString);
             changed = true;
         }
 
@@ -1034,12 +1069,12 @@ public class MainPanel extends javax.swing.JPanel implements IRModelEventListene
             jFormattedTextFieldWaveMax.setValue(inputParam.getWaveMax() / MICRO_METER);
 
             // arrange observable checkboxes
-            jCheckBoxUseVis.setEnabled(hasOIData && oifitsFile.hasOiVis());
+            jComboBoxUseVis.setEnabled(hasOIData && oifitsFile.hasOiVis());
             jCheckBoxUseVis2.setEnabled(hasOIData && oifitsFile.hasOiVis2());
-            jCheckBoxUseT3.setEnabled(hasOIData && oifitsFile.hasOiT3());
-            jCheckBoxUseVis.setSelected(hasOIData && inputParam.useVis());
+            jComboBoxUseT3.setEnabled(hasOIData && oifitsFile.hasOiT3());
+            jComboBoxUseVis.setSelectedItem(inputParam.useVis());
             jCheckBoxUseVis2.setSelected(hasOIData && inputParam.useVis2());
-            jCheckBoxUseT3.setSelected(hasOIData && inputParam.useT3());
+            jComboBoxUseT3.setSelectedItem(inputParam.useT3());
 
             // perform analysis
             final List<String> failures = new LinkedList<String>();

--- a/src/main/java/fr/jmmc/oimaging/gui/MainPanel.java
+++ b/src/main/java/fr/jmmc/oimaging/gui/MainPanel.java
@@ -547,7 +547,7 @@ public class MainPanel extends javax.swing.JPanel implements IRModelEventListene
 
         jPanel1.setLayout(new java.awt.GridBagLayout());
 
-        jComboBoxUseVis.setModel(new DefaultComboBoxModel<String>(fr.jmmc.oitools.image.ImageOiInputParam.VIS2_T3_VALUES));
+        jComboBoxUseVis.setModel(new DefaultComboBoxModel<String>(ImageOiInputParam.USE_VALUES));
         jComboBoxUseVis.addActionListener(new java.awt.event.ActionListener() {
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 jComboBoxUseVisActionPerformed(evt);
@@ -575,7 +575,7 @@ public class MainPanel extends javax.swing.JPanel implements IRModelEventListene
         gridBagConstraints.insets = new java.awt.Insets(2, 2, 2, 2);
         jPanel1.add(jCheckBoxUseVis2, gridBagConstraints);
 
-        jComboBoxUseT3.setModel(new DefaultComboBoxModel<String>(fr.jmmc.oitools.image.ImageOiInputParam.VIS2_T3_VALUES));
+        jComboBoxUseT3.setModel(new DefaultComboBoxModel<String>(ImageOiInputParam.USE_VALUES));
         jComboBoxUseT3.addActionListener(new java.awt.event.ActionListener() {
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 jComboBoxUseT3ActionPerformed(evt);
@@ -970,7 +970,7 @@ public class MainPanel extends javax.swing.JPanel implements IRModelEventListene
         // Target
         mString = params.getTarget();
         wString = (String) jComboBoxTarget.getSelectedItem();
-        if ((mString != null && !mString.equals(wString)) || (wString != null && !wString.equals(mString))) {
+        if (!ObjectUtils.areEquals(mString, wString)) {
             params.setTarget(wString);
             changed = true;
         }
@@ -995,24 +995,24 @@ public class MainPanel extends javax.swing.JPanel implements IRModelEventListene
         }
 
         // observables
-        mString = params.useVis();
+        mString = params.getUseVis();
         wString = (String) jComboBoxUseVis.getSelectedItem();
-        if ((mString != null && !mString.equals(wString)) || (wString != null && !wString.equals(mString))) {
-            params.useVis(wString);
+        if (!ObjectUtils.areEquals(mString, wString)) {
+            params.setUseVis(wString);
             changed = true;
         }
 
-        mFlag = params.useVis2();
+        mFlag = params.isUseVis2();
         wFlag = jCheckBoxUseVis2.isSelected();
         if (mFlag != wFlag) {
-            params.useVis2(wFlag);
+            params.setUseVis2(wFlag);
             changed = true;
         }
 
-        mString = params.useT3();
+        mString = params.getUseT3();
         wString = (String) jComboBoxUseT3.getSelectedItem();
-        if ((mString != null && !mString.equals(wString)) || (wString != null && !wString.equals(mString))) {
-            params.useT3(wString);
+        if (!ObjectUtils.areEquals(mString, wString)) {
+            params.setUseT3(wString);
             changed = true;
         }
 
@@ -1072,9 +1072,9 @@ public class MainPanel extends javax.swing.JPanel implements IRModelEventListene
             jComboBoxUseVis.setEnabled(hasOIData && oifitsFile.hasOiVis());
             jCheckBoxUseVis2.setEnabled(hasOIData && oifitsFile.hasOiVis2());
             jComboBoxUseT3.setEnabled(hasOIData && oifitsFile.hasOiT3());
-            jComboBoxUseVis.setSelectedItem(inputParam.useVis());
-            jCheckBoxUseVis2.setSelected(hasOIData && inputParam.useVis2());
-            jComboBoxUseT3.setSelectedItem(inputParam.useT3());
+            jComboBoxUseVis.setSelectedItem(inputParam.getUseVis());
+            jCheckBoxUseVis2.setSelected(hasOIData && inputParam.isUseVis2());
+            jComboBoxUseT3.setSelectedItem(inputParam.getUseT3());
 
             // perform analysis
             final List<String> failures = new LinkedList<String>();

--- a/src/main/java/fr/jmmc/oimaging/gui/MainPanel.java
+++ b/src/main/java/fr/jmmc/oimaging/gui/MainPanel.java
@@ -31,6 +31,7 @@ import fr.jmmc.oimaging.model.IRModelEvent;
 import fr.jmmc.oimaging.model.IRModelEventListener;
 import fr.jmmc.oimaging.model.IRModelEventType;
 import fr.jmmc.oimaging.model.IRModelManager;
+import fr.jmmc.oimaging.services.ServiceList;
 import fr.jmmc.oimaging.services.ServiceResult;
 import fr.jmmc.oitools.image.FitsImageHDU;
 import fr.jmmc.oitools.image.FitsUnit;
@@ -1069,7 +1070,10 @@ public class MainPanel extends javax.swing.JPanel implements IRModelEventListene
             jFormattedTextFieldWaveMax.setValue(inputParam.getWaveMax() / MICRO_METER);
 
             // arrange observable checkboxes
-            jComboBoxUseVis.setEnabled(hasOIData && oifitsFile.hasOiVis());
+            // BSMEM should always have USE_VIS disabled
+            final boolean isBSMEM = currentModel.getSelectedService().getProgram().equals(ServiceList.CMD_BSMEM);
+            jLabelUseVis.setEnabled(!isBSMEM);
+            jComboBoxUseVis.setEnabled(hasOIData && oifitsFile.hasOiVis() && !isBSMEM);
             jCheckBoxUseVis2.setEnabled(hasOIData && oifitsFile.hasOiVis2());
             jComboBoxUseT3.setEnabled(hasOIData && oifitsFile.hasOiT3());
             jComboBoxUseVis.setSelectedItem(inputParam.getUseVis());

--- a/src/main/java/fr/jmmc/oimaging/gui/MainPanel.java
+++ b/src/main/java/fr/jmmc/oimaging/gui/MainPanel.java
@@ -997,7 +997,7 @@ public class MainPanel extends javax.swing.JPanel implements IRModelEventListene
         // observables
         mString = params.useVis();
         wString = (String) jComboBoxUseVis.getSelectedItem();
-        if (mString != null && !mString.equals(wString)) {
+        if ((mString != null && !mString.equals(wString)) || (wString != null && !wString.equals(mString))) {
             params.useVis(wString);
             changed = true;
         }
@@ -1011,7 +1011,7 @@ public class MainPanel extends javax.swing.JPanel implements IRModelEventListene
 
         mString = params.useT3();
         wString = (String) jComboBoxUseT3.getSelectedItem();
-        if (mString != null && !mString.equals(wString)) {
+        if ((mString != null && !mString.equals(wString)) || (wString != null && !wString.equals(mString))) {
             params.useT3(wString);
             changed = true;
         }

--- a/src/main/java/fr/jmmc/oimaging/gui/ViewerPanel.java
+++ b/src/main/java/fr/jmmc/oimaging/gui/ViewerPanel.java
@@ -36,8 +36,6 @@ import java.awt.BorderLayout;
 import java.awt.Component;
 import java.awt.Font;
 import java.awt.GridLayout;
-import java.awt.event.MouseAdapter;
-import java.awt.event.MouseEvent;
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
@@ -397,20 +395,6 @@ public class ViewerPanel extends javax.swing.JPanel implements ChangeListener {
                         final FitsImage image = imageHDU.getFitsImages().get(0);
                         panel.setFitsImage(image);
                     }
-
-                    // TODO FIX: not working !!
-                    // see JFreeChart listeners ?
-                    panel.addMouseListener(new MouseAdapter() {
-                        @Override
-                        public void mouseClicked(MouseEvent e) {
-                            if (e.getClickCount() == 2) {
-                                System.out.println("double clicked");
-                                jPanelImage.removeAll();
-                                displayResult(result);
-                            }
-                            System.out.println("not double clicked");
-                        }
-                    });
                 }
             }
             setTabMode(SHOW_MODE.GRID);

--- a/src/main/java/fr/jmmc/oimaging/model/IRModel.java
+++ b/src/main/java/fr/jmmc/oimaging/model/IRModel.java
@@ -24,6 +24,7 @@ import fr.jmmc.oitools.meta.OIFitsStandard;
 import fr.jmmc.oitools.meta.Types;
 import fr.jmmc.oitools.model.OIFitsChecker;
 import fr.jmmc.oitools.model.OIFitsFile;
+import fr.jmmc.oitools.model.OIFitsLoader;
 import fr.jmmc.oitools.model.OIFitsWriter;
 import fr.jmmc.oitools.model.range.Range;
 import fr.nom.tam.fits.FitsDate;
@@ -821,6 +822,9 @@ public final class IRModel {
 
         if (serviceResult.isValid()) {
             serviceResult.setIndex(resultCounter.incrementAndGet());
+
+            // fix OIFitsFile
+            OIFitsLoader.fixOIFitsFile(serviceResult.getOifitsFile());
 
             postProcessOIFitsFile(serviceResult);
 

--- a/src/main/java/fr/jmmc/oimaging/model/IRModel.java
+++ b/src/main/java/fr/jmmc/oimaging/model/IRModel.java
@@ -24,7 +24,6 @@ import fr.jmmc.oitools.meta.OIFitsStandard;
 import fr.jmmc.oitools.meta.Types;
 import fr.jmmc.oitools.model.OIFitsChecker;
 import fr.jmmc.oitools.model.OIFitsFile;
-import fr.jmmc.oitools.model.OIFitsLoader;
 import fr.jmmc.oitools.model.OIFitsWriter;
 import fr.jmmc.oitools.model.range.Range;
 import fr.nom.tam.fits.FitsDate;
@@ -224,19 +223,19 @@ public final class IRModel {
 
         // Reset observable use according available tables
         if (oifitsFile.hasOiVis()) {
-            if (inputParam.useVis() == null) {
-                inputParam.useVis(ImageOiInputParam.VIS2_T3_ALL);
+            if (inputParam.getUseVis() == null) {
+                inputParam.setUseVis(ImageOiInputParam.USE_ALL);
             }
         } else {
-            inputParam.useVis(ImageOiInputParam.VIS2_T3_NONE);
+            inputParam.setUseVis(ImageOiInputParam.USE_NONE);
         }
-        inputParam.useVis2(oifitsFile.hasOiVis2());
+        inputParam.setUseVis2(oifitsFile.hasOiVis2());
         if (oifitsFile.hasOiT3()) {
-            if (inputParam.useT3() == null) {
-                inputParam.useT3(ImageOiInputParam.VIS2_T3_ALL);
+            if (inputParam.getUseT3() == null) {
+                inputParam.setUseT3(ImageOiInputParam.USE_ALL);
             }
         } else {
-            inputParam.useT3(ImageOiInputParam.VIS2_T3_NONE);
+            inputParam.setUseT3(ImageOiInputParam.USE_NONE);
         }
 
         // get roles in the given list order:
@@ -834,9 +833,6 @@ public final class IRModel {
 
         if (serviceResult.isValid()) {
             serviceResult.setIndex(resultCounter.incrementAndGet());
-
-            // fix OIFitsFile
-            OIFitsLoader.fixOIFitsFile(serviceResult.getOifitsFile());
 
             postProcessOIFitsFile(serviceResult);
 

--- a/src/main/java/fr/jmmc/oimaging/model/IRModel.java
+++ b/src/main/java/fr/jmmc/oimaging/model/IRModel.java
@@ -222,9 +222,9 @@ public final class IRModel {
         inputParam.setWaveMax(effWaveRange.getMax());
 
         // Reset observable use according available tables
-        inputParam.useVis(oifitsFile.hasOiVis());
+        inputParam.useVis(oifitsFile.hasOiVis() ? ImageOiInputParam.VIS2_T3_ALL : ImageOiInputParam.VIS2_T3_NONE);
         inputParam.useVis2(oifitsFile.hasOiVis2());
-        inputParam.useT3(oifitsFile.hasOiT3());
+        inputParam.useT3(oifitsFile.hasOiT3() ? ImageOiInputParam.VIS2_T3_ALL : ImageOiInputParam.VIS2_T3_NONE);
 
         // get roles in the given list order:
         final List<Role> hdusRoles = getHdusRoles(oifitsFile);

--- a/src/main/java/fr/jmmc/oimaging/model/IRModel.java
+++ b/src/main/java/fr/jmmc/oimaging/model/IRModel.java
@@ -223,9 +223,21 @@ public final class IRModel {
         inputParam.setWaveMax(effWaveRange.getMax());
 
         // Reset observable use according available tables
-        inputParam.useVis(oifitsFile.hasOiVis() ? ImageOiInputParam.VIS2_T3_ALL : ImageOiInputParam.VIS2_T3_NONE);
+        if (oifitsFile.hasOiVis()) {
+            if (inputParam.useVis() == null) {
+                inputParam.useVis(ImageOiInputParam.VIS2_T3_ALL);
+            }
+        } else {
+            inputParam.useVis(ImageOiInputParam.VIS2_T3_NONE);
+        }
         inputParam.useVis2(oifitsFile.hasOiVis2());
-        inputParam.useT3(oifitsFile.hasOiT3() ? ImageOiInputParam.VIS2_T3_ALL : ImageOiInputParam.VIS2_T3_NONE);
+        if (oifitsFile.hasOiT3()) {
+            if (inputParam.useT3() == null) {
+                inputParam.useT3(ImageOiInputParam.VIS2_T3_ALL);
+            }
+        } else {
+            inputParam.useT3(ImageOiInputParam.VIS2_T3_NONE);
+        }
 
         // get roles in the given list order:
         final List<Role> hdusRoles = getHdusRoles(oifitsFile);

--- a/src/main/java/fr/jmmc/oimaging/model/IRModelManager.java
+++ b/src/main/java/fr/jmmc/oimaging/model/IRModelManager.java
@@ -200,9 +200,6 @@ public final class IRModelManager {
 
                     oifitsFile = OIFitsLoader.loadOIFits(OIFitsStandard.VERSION_1, checker, localCopy.getAbsolutePath());
                     oifitsFile.setSourceURI(new URI(fileLocation));
-
-                    // fix OIFitsFile
-                    OIFitsLoader.fixOIFitsFile(oifitsFile);
                 } else {
                     // download failed:
                     oifitsFile = null;

--- a/src/main/java/fr/jmmc/oimaging/model/IRModelManager.java
+++ b/src/main/java/fr/jmmc/oimaging/model/IRModelManager.java
@@ -200,6 +200,9 @@ public final class IRModelManager {
 
                     oifitsFile = OIFitsLoader.loadOIFits(OIFitsStandard.VERSION_1, checker, localCopy.getAbsolutePath());
                     oifitsFile.setSourceURI(new URI(fileLocation));
+
+                    // fix OIFitsFile
+                    OIFitsLoader.fixOIFitsFile(oifitsFile);
                 } else {
                     // download failed:
                     oifitsFile = null;

--- a/src/main/java/fr/jmmc/oimaging/services/software/BsmemInputParam.java
+++ b/src/main/java/fr/jmmc/oimaging/services/software/BsmemInputParam.java
@@ -48,6 +48,9 @@ public final class BsmemInputParam extends SoftwareInputParam {
             params.removeKeyword(ImageOiConstants.KEYWORD_RGL_WGT);
         }
 
+        // BSMEM never uses VIS:
+        params.setUseVis(ImageOiInputParam.USE_NONE);
+
         if (applyDefaults) {
             // specific default values for BSMEM:
             params.setAutoWgt(true);

--- a/src/test/java/fest/OImagingDocJUnitTest.java
+++ b/src/test/java/fest/OImagingDocJUnitTest.java
@@ -89,6 +89,7 @@ public final class OImagingDocJUnitTest extends JmcsFestSwingJUnitTestCase {
 
         // Set special system properties:
         System.setProperty("oimaging.devMode", "false");
+        System.setProperty("RemoteExecutionMode.local", "false"); // use local docker
 
         // Start application:
         JmcsFestSwingJUnitTestCase.startApplication(


### PR DESCRIPTION
Associated to issue https://github.com/JMMC-OpenDev/oimaging/issues/18

- Change the type of VIS & T3 from Boolean to String, replaces the GUI fields from checkboxes to comboboxes with a list of string constants as model.
- call function fixOiFitsFile to accept old oifitsfile that still contains boolean values for these params.