### PR TITLE
hide RGL_WGT when AUTO_RGL is true, in the input form

### DIFF
--- a/src/main/java/fr/jmmc/oimaging/gui/SoftwareSettingsPanel.java
+++ b/src/main/java/fr/jmmc/oimaging/gui/SoftwareSettingsPanel.java
@@ -794,10 +794,10 @@ public class SoftwareSettingsPanel extends javax.swing.JPanel {
 
             jFormattedTextFieldRglWgt.setValue(inputParam.getRglWgt());
             show = service.supportsStandardKeyword(ImageOiConstants.KEYWORD_RGL_WGT);
-            jLabelRglWgt.setVisible(show);
-            jFormattedTextFieldRglWgt.setVisible(show);
             // change visibility / enabled if RglWgt keyword exists (bsmem auto)
             final boolean enabled = inputParam.hasKeywordMeta(ImageOiConstants.KEYWORD_RGL_WGT);
+            jLabelRglWgt.setVisible(show && enabled);
+            jFormattedTextFieldRglWgt.setVisible(show && enabled);
             jLabelRglWgt.setEnabled(enabled);
             jFormattedTextFieldRglWgt.setEnabled(enabled);
 


### PR DESCRIPTION
It was already disabled, it is now hidden too. The keyword will _not_ be given to the software so it is better to hide it from the GUI