### PR TITLE
force wisard input form to have init img to be run

### DIFF
--- a/src/main/java/fr/jmmc/oimaging/services/software/WisardInputParam.java
+++ b/src/main/java/fr/jmmc/oimaging/services/software/WisardInputParam.java
@@ -28,7 +28,6 @@ public final class WisardInputParam extends SoftwareInputParam {
 
     /** Parameters that can be missing. */
     public static final Set<String> SUPPORTED_MISSING_KEYWORDS = new HashSet<>(Arrays.asList(
-            ImageOiConstants.KEYWORD_INIT_IMG,
             ImageOiConstants.KEYWORD_RGL_PRIO
     ));
 


### PR DESCRIPTION
Related to https://github.com/JMMC-OpenDev/oimaging/issues/86

Just remove INIT_IMG from the supported missing list