### PR TITLE
fix bug 123 parameters tab

### DIFF
--- a/src/main/java/fr/jmmc/oimaging/gui/ViewerPanel.java
+++ b/src/main/java/fr/jmmc/oimaging/gui/ViewerPanel.java
@@ -321,6 +321,11 @@ public class ViewerPanel extends javax.swing.JPanel implements ChangeListener {
 
                 displayImage(imageHdus, imageHDU);
                 displayOiFitsAndParams(oifitsFile, target);
+            } else {
+                // displays empty content for oifits data, images and parameters. keeps execution log content.
+                displaySelection(null);
+                displayImage(null, null);
+                displayOiFitsAndParams(null, null);
             }
             /*else {
                 lastResultPanel = jPanelLogViewer;


### PR DESCRIPTION
See https://github.com/JMMC-OpenDev/oimaging/issues/123

it displays empty content for image, oifits and parameters tab when the selected result is invalid.