### PR TITLE
fix bug 87 sparco model values to upper case

### DIFF
--- a/src/main/java/fr/jmmc/oimaging/services/software/SparcoInputParam.java
+++ b/src/main/java/fr/jmmc/oimaging/services/software/SparcoInputParam.java
@@ -70,9 +70,9 @@ public final class SparcoInputParam extends MiraInputParam {
     // TODO: support for 'spectrum' for a spectrum specified in an ascii file (TO BE IMPLEMENTED)
     public static final String[] KEYWORD_SPEC_LIST = new String[]{KEYWORD_SPEC_POW, KEYWORD_SPEC_BB};
 
-    public static final String KEYWORD_MODEL_STAR = "star";
+    public static final String KEYWORD_MODEL_STAR = "STAR";
     public static final String KEYWORD_MODEL_UD = "UD";
-    public static final String KEYWORD_MODEL_BG = "bg";
+    public static final String KEYWORD_MODEL_BG = "BG";
     // TODO: support for 'image' computed from specified fits-file (TO BE IMPLEMENTED)
     public static final String[] KEYWORD_MODEL_LIST = new String[]{KEYWORD_MODEL_STAR, KEYWORD_MODEL_UD, KEYWORD_MODEL_BG};
 


### PR DESCRIPTION
- sets sparco values to UPPER CASE
- so it always accords with sparco software which puts every value into upper case

fixes https://github.com/JMMC-OpenDev/oimaging/issues/87